### PR TITLE
Fix validation and parent error messages typos

### DIFF
--- a/src/component/component/validate.js
+++ b/src/component/component/validate.js
@@ -41,7 +41,7 @@ function validatePropDefinitions<P>(options : ComponentOptionsType<P>) {
 export function validate<P>(options : ?ComponentOptionsType<P>) { // eslint-ignore-line
 
     if (!options) {
-        throw new Error(`Expecred options to be passed`);
+        throw new Error(`Expected options to be passed`);
     }
 
     if (!options.tag || !options.tag.match(/^[a-z0-9-]+$/)) {

--- a/src/component/parent/index.js
+++ b/src/component/parent/index.js
@@ -644,7 +644,7 @@ export class ParentComponent<P> extends BaseComponent<P> {
                         return val(original, override).apply(this, arguments);
                     }
 
-                    throw new Error(`Expected delgate to be CALL_ORIGINAL, CALL_DELEGATE, or factory method`);
+                    throw new Error(`Expected delegate to be CALL_ORIGINAL, CALL_DELEGATE, or factory method`);
                 });
             };
         }


### PR DESCRIPTION
This fixes two typos found in validation and parent error messages.