### PR TITLE
Fix: query values should be escaped

### DIFF
--- a/src/component/parent/props.js
+++ b/src/component/parent/props.js
@@ -265,6 +265,9 @@ export function propsToQuery<P>(propsDef : BuiltInPropsDefinitionType<P>, props 
         });
 
     })).then(() => {
+        Object.keys(params).forEach(key => {
+            params[key] = escape(params[key]);
+        });
         return params;
     });
 }


### PR DESCRIPTION
escaping every query param value instead of in xcomponent clients.