### PR TITLE
feat(validate-call-onerror-zoidv6): Calling  prop, if it exists, if prop validation throws an error

### DIFF
--- a/src/component/component/index.js
+++ b/src/component/component/index.js
@@ -61,7 +61,7 @@ export type ComponentOptionsType<P> = {
     containerTemplate? : (RenderOptionsType) => HTMLElement,
     prerenderTemplate? : (RenderOptionsType) => HTMLElement,
 
-    validate? : (Component<P>, PropsType) => void,
+    validate? : (Component<P>, UserPropsDefinitionType<P>) => void,
 
     unsafeRenderTo? : boolean
 };

--- a/src/component/parent/index.js
+++ b/src/component/parent/index.js
@@ -87,7 +87,15 @@ export class ParentComponent<P> extends BaseComponent<P> {
         this.validateParentDomain();
 
         this.context = context;
-        this.setProps(props);
+
+        try {
+            this.setProps(props);
+        } catch (err) {
+            if (props.onError) {
+                props.onError(err);
+            }
+            throw err;
+        }
 
         if (this.props.logLevel) {
             setLogLevel(this.props.logLevel);

--- a/test/component.jsx
+++ b/test/component.jsx
@@ -114,6 +114,12 @@ export let testComponent = zoid.create({
 
     containerTemplate: containerTemplate,
 
+    validate(component, { invalidate }) {
+        if (invalidate === true) {
+            throw new Error('Invalidated prop is defined as true');
+        }
+    },
+
     props: {
         childEntered: {
             type: 'function',
@@ -181,6 +187,22 @@ export let testComponent = zoid.create({
         run: {
             type: 'string',
             required: false
+        },
+
+        invalidate: {
+            type:     'boolean',
+            required: false
+        },
+
+        validateProp: {
+            type:     'string',
+            required: false,
+
+            validate(validate) {
+                if (validate && validate !== 'validate') {
+                    throw new Error('String does not equal "validate"');
+                }
+            }
         }
     }
 });

--- a/test/tests/error.js
+++ b/test/tests/error.js
@@ -181,7 +181,43 @@ describe('zoid error cases', () => {
         }
     });
 
-    it('should call onclose when a popup is closed by someone other than zoid', done => {
+    it('should run validate function on props, and pass up error when thrown', done => {
+        testComponent.renderPopup({
+            validateProp: 'foo'
+        }).catch(() => {
+            done();
+        });
+    });
+
+    it('should run validate function on props, and call onError when error is thrown', done => {
+        testComponent.renderPopup({
+            validateProp: 'foo',
+
+            onError() {
+                done();
+            }
+        });
+    });
+
+    it('should run validate function on component, and pass up error when thrown', done => {
+        testComponent.renderPopup({
+            invalidate: true
+        }).catch(() => {
+            done();
+        });
+    });
+
+    it('should run validate function on props, and call onError when error is thrown', done => {
+        testComponent.renderPopup({
+            invalidate: true,
+
+            onError() {
+                done();
+            }
+        });
+    });
+
+    it('should call onclose when a popup is closed by someone other tha zoid', done => {
 
         testComponent.renderPopup({
 


### PR DESCRIPTION
Again for the `zoid-v6` branch