### PR TITLE
Update React example to use Component.driver syntax

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -129,9 +129,16 @@ set up bindings for these frameworks:
 Drop the component in any `render()` method:
 
 ```javascript
+let MyReactLoginComponent = MyLoginComponent.driver('react', {
+    React:    React, 
+    ReactDOM: ReactDOM
+});
+```
+
+```javascript
 render: function() {
     return (
-        <MyLoginComponent.react prefilledEmail='foo@bar.com' onLogin={onLogin} />
+        <MyReactLoginComponent prefilledEmail='foo@bar.com' onLogin={onLogin} />
     );
 }
 ```


### PR DESCRIPTION
This updates the React example snippet to match the example on `docs/api.md`. I don't believe that Zoid has a `react` property on the Component instance anymore, so this updates it to use `Component.driver` and specifies react as the framework.