### PR TITLE
Fix Typo in Error: `zoid desroyed all`

### DIFF
--- a/src/component/component.js
+++ b/src/component/component.js
@@ -419,7 +419,7 @@ export function destroyAll() : ZalgoPromise<void> {
     const global = getGlobal();
     global.activeComponents = global.activeComponents || [];
     while (global.activeComponents.length) {
-        results.push(global.activeComponents[0].destroy(new Error(`zoid desroyed all`), false));
+        results.push(global.activeComponents[0].destroy(new Error(`zoid destroyed all`), false));
     }
 
     return ZalgoPromise.all(results).then(noop);


### PR DESCRIPTION
Just got this error on our app, I wanted to fix the typo 👍 

Thanks for open sourcing