### PR TITLE
Update documentation to avoid scheme-relative URLs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,7 +18,9 @@ tag: 'my-component-tag'
 
 #### url `string | ({ props }) => string` [required]
 
-The full url that will be loaded when your component is rendered, or a function returning the url
+The full url that will be loaded when your component is rendered, or a function returning the url.
+
+This must include a protocol (http:, https:, or about:); it cannot be scheme-relative.
 
 ```javascript
 url: 'https://www.my-site.com/mycomponent'


### PR DESCRIPTION
Per the HTML spec you can put a scheme-relative url, e.g. `//google.com` as the src of an iframe: https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src

But Zoid sniffs the protocol in isSameDomain (from cross-domain-utils) so it expects http or https. If a protocol is not provided, the preload page spinner spins infinitely as in #202.

This makes it explicit that a protocol should be provided.