### PR TITLE
Allow tag names without dashes

### DIFF
--- a/src/component/validate.js
+++ b/src/component/validate.js
@@ -49,7 +49,7 @@ export function validate<P>(options : ?ComponentOptionsType<P>) { // eslint-igno
     }
 
     // eslint-disable-next-line security/detect-unsafe-regex, unicorn/no-unsafe-regex
-    if (!options.tag || !options.tag.match(/^([a-z0-9]+-)+[a-z0-9]+$/)) {
+    if (!options.tag || !options.tag.match(/^([a-z0-9][a-z0-9-]*)+[a-z0-9]+$/)) {
         throw new Error(`Invalid options.tag: ${ options.tag }`);
     }
 

--- a/test/tests/validation.js
+++ b/test/tests/validation.js
@@ -44,6 +44,31 @@ describe('zoid validation errors', () => {
         });
     });
 
+    it('should throw validation errors when a component is created with trailing dash in tag name', () => {
+        return expectError('Malformed tag name', () => {
+            window.zoid.create({
+                url: 'http://foo.com/bar',
+                tag: 'my-component-'
+            });
+        });
+    });
+
+    it('should throw validation errors when a component is created with leading dash in tag name', () => {
+        return expectError('Malformed tag name', () => {
+            window.zoid.create({
+                url: 'http://foo.com/bar',
+                tag: '-my-component'
+            });
+        });
+    });
+
+    it('should NOT throw validation errors when a component is created NO dash in tag name', () => {
+        return window.zoid.create({
+            url: 'http://foo.com/bar',
+            tag: 'component'
+        });
+    });
+
     it('should throw validation errors when a component is created with Special chars in tag name', () => {
         return expectError('Special chars in tag name', () => {
             window.zoid.create({


### PR DESCRIPTION
Is there a specific reason to enforce a dash in the tag name? I stumbled upon this one while upgrading from zoid v6 (where dashless tag names were still working) to v9 and it came pretty unexpected.

I've added a test-case to cover my change however I'm not sure whether the place where I put it is right because it's the first test in that file that doesn't expect an error.

If you have an idea where to put the test case instead just let me know and I'll amend my PR.