### PR TITLE
Fix typo in API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -326,7 +326,7 @@ var MyLoginZoidComponent = zoid.create({
     tag: 'my-login',
     url: 'https://www.mysite.com/login',
 
-    prerenderTemplate: function({ doc ) {
+    prerenderTemplate: function({ doc }) {
         return (
             <p>
                 Please wait while the component loads...


### PR DESCRIPTION
Found this typo in docs after copy/pasting the code on my files.