### PR TITLE
Fixing typo in API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -257,8 +257,8 @@ var MyLoginZoidComponent = zoid.create({
                     `}
                 </style>
 
-                <frame el={ frame } />
-                <frame el={ prerenderFrame } />
+                <node el={ frame } />
+                <node el={ prerenderFrame } />
             </div>
         ).render(dom({ doc }));
     }


### PR DESCRIPTION
`frame` element should be `node` element