### PR TITLE
fix(): use console warning for zoid version mismatch

### DIFF
--- a/src/child/child.js
+++ b/src/child/child.js
@@ -122,7 +122,7 @@ export function childComponent<P>(options : NormalizedComponentOptionsType<P>) :
     }
 
     if (childPayload.version !== __ZOID__.__VERSION__) {
-        throw new Error(`Parent window has zoid version ${ childPayload.version }, child window has version ${ __ZOID__.__VERSION__ }`);
+        console.warn(`Zoid version mismatch detected. Parent window has zoid version ${ childPayload.version }, child window has version ${ __ZOID__.__VERSION__ }`);
     }
 
     const { parent: parentRef, parentDomain, exports, context, props: propsRef } = childPayload;


### PR DESCRIPTION
Fixes #225 

For various reasons it's not always possible to deploy the parent / child at the same time.

Currently zoid crashes on a version mismatch even if there are no breaking changes between two versions.

Rationale for using `console.warn()` instead of `new Error()`:
- In case of a breaking change the software still crashes with a warning on console
- non-breaking changes allow independent deployments (think of a security patch)

Ultimately it's the developers responsibility to make sure that the software is working as intended and that there are no console warnings.