### PR TITLE
Maint: Debug is blocking validation

### DIFF
--- a/src/component/props.js
+++ b/src/component/props.js
@@ -169,21 +169,19 @@ export function getBuiltInProps<P>() : BuiltInPropsDefinitionType<P> {
             required:      false,
             allowDelegate: true,
             validate:      ({ value }) => {
-                if (__DEBUG__) {
-                    if (!isWindow(value) && !ProxyWindow.isProxyWindow(value)) {
-                        throw new Error(`Expected Window or ProxyWindow`);
+                if (!isWindow(value) && !ProxyWindow.isProxyWindow(value)) {
+                    throw new Error(`Expected Window or ProxyWindow`);
+                }
+
+                if (isWindow(value)) {
+                    // $FlowFixMe
+                    if (isWindowClosed(value)) {
+                        throw new Error(`Window is closed`);
                     }
-    
-                    if (isWindow(value)) {
-                        // $FlowFixMe
-                        if (isWindowClosed(value)) {
-                            throw new Error(`Window is closed`);
-                        }
-    
-                        // $FlowFixMe
-                        if (!isSameDomain(value)) {
-                            throw new Error(`Window is not same domain`);
-                        }
+
+                    // $FlowFixMe
+                    if (!isSameDomain(value)) {
+                        throw new Error(`Window is not same domain`);
                     }
                 }
             },


### PR DESCRIPTION
Validation errors were being blocked for edge case where user closes popup window quickly when `onClick`is implemented and causes iframe to show in window.  The debug flag was blocking error messages that are valuable for debugging this issue.

https://github.com/paypal/paypal-checkout-components/issues/1339