### PR TITLE
feat(bridge): allow bridgeUrl to be a function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -474,14 +474,22 @@ validate: function({ props }) {
 }
 ```
 
-#### bridgeUrl `string `
+#### bridgeUrl `string | ({ props }) => string`
 
-The url for a [post-robot bridge](https://github.com/krakenjs/post-robot#parent-to-popup-messaging). Will be automatically loaded in a hidden iframe when a popup component is rendered, to allow communication between the parent window and the popup in IE/Edge.
+The url or a function returning the url for a [post-robot bridge](https://github.com/krakenjs/post-robot#parent-to-popup-messaging). Will be automatically loaded in a hidden iframe when a popup component is rendered, to allow communication between the parent window and the popup in IE/Edge.
 
 This is only necessary if you are creating a popup component which needs to run in IE and/or Edge.
 
 ```javascript
 bridgeUrl: 'https://foo.com/bridge'
+```
+
+```javascript
+bridgeUrl: ({ props }) => {
+    return (props.env === 'development')
+        ? 'http://foo.dev/bridge'
+        : 'https://foo.com/bridge';
+}
 ```
 
 # `Component`

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -723,6 +723,14 @@ export function parentComponent<P>(options : NormalizedComponentOptionsType<P>, 
         });
     };
 
+    const getBridgeUrl = () : ?string => {
+        if (typeof options.bridgeUrl === 'function') {
+            return options.bridgeUrl({ props });
+        }
+
+        return options.bridgeUrl;
+    };
+
     const openBridge = (proxyWin : ProxyWindow, domain : string, context : $Values<typeof CONTEXT>) : ?ZalgoPromise<?CrossDomainWindowType> => {
         if (__POST_ROBOT__.__IE_POPUP_SUPPORT__) {
             return ZalgoPromise.try(() => {
@@ -733,7 +741,7 @@ export function parentComponent<P>(options : NormalizedComponentOptionsType<P>, 
                     return;
                 }
 
-                const bridgeUrl = options.bridgeUrl;
+                const bridgeUrl = getBridgeUrl();
 
                 if (!bridgeUrl) {
                     throw new Error(`Bridge needed to render ${ context }`);


### PR DESCRIPTION
`url` and `bridgeUrl` are on the same domain, it would be nice for `bridgeUrl` to also accepts a function so that we can have different bridge URLs for different environments.