### PR TITLE
closes #291 - make sure process exists before checking process.env an…

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@
 // eslint-disable-next-line no-process-env
 if (process && process.env && process.env.ZOID_FRAME_ONLY) {
     // $FlowFixMe
-    module.exports = require("./dist/zoid.frame");
+    module.exports = require('./dist/zoid.frame');
     // $FlowFixMe
     module.exports.default = module.exports;
 } else {
     // $FlowFixMe
-    module.exports = require("./dist/zoid");
+    module.exports = require('./dist/zoid');
     // $FlowFixMe
     module.exports.default = module.exports;
 }

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@
 /* eslint import/no-commonjs: 0 */
 
 // eslint-disable-next-line no-process-env
-if (process.env.ZOID_FRAME_ONLY) {
+if (process && process.env && process.env.ZOID_FRAME_ONLY) {
     // $FlowFixMe
-    module.exports = require('./dist/zoid.frame');
+    module.exports = require("./dist/zoid.frame");
     // $FlowFixMe
     module.exports.default = module.exports;
 } else {
     // $FlowFixMe
-    module.exports = require('./dist/zoid');
+    module.exports = require("./dist/zoid");
     // $FlowFixMe
     module.exports.default = module.exports;
 }

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@
 /* eslint import/no-commonjs: 0 */
 
 // eslint-disable-next-line no-process-env
-if (processs && process.env && process.env.ZOID_FRAME_ONLY) {
+if (process && process.env && process.env.ZOID_FRAME_ONLY) {
     // $FlowFixMe
-    module.exports = require("./dist/zoid.frame");
+    module.exports = require('./dist/zoid.frame');
     // $FlowFixMe
     module.exports.default = module.exports;
 } else {
     // $FlowFixMe
-    module.exports = require("./dist/zoid");
+    module.exports = require('./dist/zoid');
     // $FlowFixMe
     module.exports.default = module.exports;
 }

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@
 /* eslint import/no-commonjs: 0 */
 
 // eslint-disable-next-line no-process-env
-if (process && process.env && process.env.ZOID_FRAME_ONLY) {
+if (processs && process.env && process.env.ZOID_FRAME_ONLY) {
     // $FlowFixMe
-    module.exports = require('./dist/zoid.frame');
+    module.exports = require("./dist/zoid.frame");
     // $FlowFixMe
     module.exports.default = module.exports;
 } else {
     // $FlowFixMe
-    module.exports = require('./dist/zoid');
+    module.exports = require("./dist/zoid");
     // $FlowFixMe
     module.exports.default = module.exports;
 }


### PR DESCRIPTION
## The issue
#291 
The `index.js` file has a problem when it is being used in an environment that does not use `process`.

## The solution
We can check if `process` exists before checking if `process.env` exists, before checking if `process.env.ZOID_FRAME_ONLY` exists

## This PR will
* Make sure `process` and `process.env` exists before checking if `process.env.ZOID_FRAME_ONLY` exists using the `logical AND` operator `&&`

## Other ways to check for existence of child keys in an object
* Use lodash library's [._get function](https://lodash.com/docs/4.17.15#get).
    * This repo does not use lodash, so we should not use lodash just for this issue.
* Use [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
    * This is not as readable.