### PR TITLE
closes #326 - add test/eslintrc.js file to estlintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ test/lib
 demo
 dist
 test/.eslintrc.js
+hi

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 test/lib
 demo
 dist
+test/.eslintrc.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,3 @@ test/lib
 demo
 dist
 test/.eslintrc.js
-hi


### PR DESCRIPTION
### The issue
#326 
The command that checks if files conform with`eslint` in the codebase checks the `test/eslintrc.js` file too. That file should go into the ignore folder or else this error occurs when someone runs the linter on their local machine:
<img width="578" alt="Screen Shot 2020-10-08 at 5 13 39 PM" src="https://user-images.githubusercontent.com/45890848/95527465-3be60800-098a-11eb-9501-ab6c07052d3d.png">

### This PR will
* Add `test/eslintrc.js` file into the `.eslintignore` file 