### PR TITLE
closes #328 - Update .travis.yml file to fix CI build failure issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
-   - "lts/*"
+  - 'lts/*'
+before_install:
+  - rm -rf node_modules
 script: npm test


### PR DESCRIPTION
### The issue
#328 
The Travis CI builds are failing, with the error being 
<img width="736" alt="Screen Shot 2020-10-08 at 5 24 37 PM" src="https://user-images.githubusercontent.com/45890848/95527786-29200300-098b-11eb-947d-ef5c4872307c.png">

What was happening was that older versions of installed modules were being used. This solution to this problem is to remove the node_modules folder before travis CI starts installing dependencies.

### This PR will
* Update the `.travis.yml` file to remove `node_modules` folder before running tests