### PR TITLE
Vue driver support for kebab-case

### DIFF
--- a/src/drivers/vue.js
+++ b/src/drivers/vue.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { noop } from 'belter/src';
+import { noop, dasherizeToCamel } from 'belter/src';
 
 import type { ComponentDriverType } from '../component';
 import { CONTEXT } from '../constants';
@@ -25,6 +25,16 @@ type VueType = {|
     component : (string, VueComponent) => RegisteredVueComponent
 |};
 
+function propsToCamelCase(props : Object) : Object {
+    for (const key of Object.keys(props)) {
+        if (key.includes('-')) {
+            props[dasherizeToCamel(key)] = props[key];
+            delete props[key];
+        }
+    }
+    return props;
+}
+
 export const vue : ComponentDriverType<*, VueType, RegisteredVueComponent> = {
 
     register: (tag, propsDef, init, Vue) => {
@@ -38,8 +48,7 @@ export const vue : ComponentDriverType<*, VueType, RegisteredVueComponent> = {
 
             mounted() {
                 const el = this.$el;
-                
-                this.parent = init({ ...this.$attrs });
+                this.parent = init({ ...propsToCamelCase(this.$attrs) });
                 this.parent.render(el, CONTEXT.IFRAME);
             },
 

--- a/src/drivers/vue.js
+++ b/src/drivers/vue.js
@@ -26,13 +26,15 @@ type VueType = {|
 |};
 
 function propsToCamelCase(props : Object) : Object {
-    for (const key of Object.keys(props)) {
+    return Object.keys(props).reduce((acc, key) => {
+        const value = props[key];
         if (key.includes('-')) {
-            props[dasherizeToCamel(key)] = props[key];
-            delete props[key];
+            acc[dasherizeToCamel(key)] = value;
+        } else {
+            acc[key] = value;
         }
-    }
-    return props;
+        return acc;
+    }, {});
 }
 
 export const vue : ComponentDriverType<*, VueType, RegisteredVueComponent> = {

--- a/test/tests/drivers.js
+++ b/test/tests/drivers.js
@@ -225,7 +225,7 @@ describe('zoid drivers', () => {
         });
     });
 
-    it('should enter a component rendered with vue and update a prop', () => {
+    it.only('should enter a component rendered with vue and update a prop with camel-case and kebab-case', () => {
         return wrapPromise(({ expect }) => {
 
             window.__component__ = () => {
@@ -253,10 +253,11 @@ describe('zoid drivers', () => {
                 render: expect('render', function render(createElement) : Object {
                     return createElement(vueComponent, {
                         attrs: {
-                            zomg:    Math.random(),
-                            foo:     this.state.foo,
-                            onLoad:  this.state.onLoad,
-                            run:     this.state.run
+                            'foo':       this.state.foo,
+                            'onLoad':    this.state.onLoad,
+                            'baz':       this.state.baz,
+                            'on-test':   this.state.onTest,
+                            'run':       this.state.run
                         }
                     });
                 }),
@@ -266,15 +267,27 @@ describe('zoid drivers', () => {
                             onLoad: expect('onLoad', () => {
                                 window.Vue.set(this.state, 'foo', expect('foo', bar => {
                                     if (bar !== 'bar') {
-                                        throw new Error(`Expected bar to be 'bar', got ${ bar }`);
+                                        throw new Error(`Expected foo to be 'bar', got ${ bar }`);
+                                    }
+                                }));
+                            }),
+                            onTest: expect('onTest', () => {
+                                window.Vue.set(this.state, 'baz', expect('baz', bar => {
+                                    if (bar !== 'bar') {
+                                        throw new Error(`Expected baz to be 'bar', got ${ bar }`);
                                     }
                                 }));
                             }),
                             run: expect('run', () => {
                                 return `
                                     return window.xprops.onLoad().then(() => {
-                                        window.xprops.onProps(() => {
-                                            window.xprops.foo('bar');
+                                        return window.xprops.onTest().then(() => {
+                                            window.xprops.onProps(() => {
+                                                window.xprops.foo('bar');
+                                            });
+                                            window.xprops.onProps(() => {
+                                                window.xprops.baz('bar');
+                                            });
                                         });
                                     });
                                 `;

--- a/test/tests/drivers.js
+++ b/test/tests/drivers.js
@@ -225,7 +225,7 @@ describe('zoid drivers', () => {
         });
     });
 
-    it.only('should enter a component rendered with vue and update a prop with camel-case and kebab-case', () => {
+    it('should enter a component rendered with vue and update a prop with camel-case and kebab-case', () => {
         return wrapPromise(({ expect }) => {
 
             window.__component__ = () => {

--- a/test/tests/drivers.js
+++ b/test/tests/drivers.js
@@ -225,7 +225,7 @@ describe('zoid drivers', () => {
         });
     });
 
-    it('should enter a component rendered with vue and update a prop with camel-case and kebab-case', () => {
+    it('should enter a component rendered with vue and update/call props with camel-case and kebab-case', () => {
         return wrapPromise(({ expect }) => {
 
             window.__component__ = () => {


### PR DESCRIPTION
**Added support to handle kebab-case props in the Vue driver**

According Vue style guide best practices the props on template components should be passed in in kebab-case format.

_Vue docs reference_: https://vuejs.org/v2/style-guide/#Prop-name-casing-strongly-recommended.
_Issue reference_: https://github.com/paypal/paypal-checkout-components/issues/1338#issuecomment-777005173
_Associated PR_: https://github.com/paypal/paypal-checkout-components/pull/1650 