### PR TITLE
Vue driver logic for prop name replacement (style prop).

### DIFF
--- a/src/drivers/vue.js
+++ b/src/drivers/vue.js
@@ -28,7 +28,12 @@ type VueType = {|
 function propsToCamelCase(props : Object) : Object {
     return Object.keys(props).reduce((acc, key) => {
         const value = props[key];
-        if (key.includes('-')) {
+        // In vue `style` is a reserved prop name
+        if (key === 'style-object' || key === 'styleObject') {
+            acc.style = value;
+            // To keep zoid as generic as possible, passing in the original prop name as well
+            acc[key] = value;
+        } else if (key.includes('-')) {
             acc[dasherizeToCamel(key)] = value;
         } else {
             acc[key] = value;

--- a/src/drivers/vue.js
+++ b/src/drivers/vue.js
@@ -32,7 +32,7 @@ function propsToCamelCase(props : Object) : Object {
         if (key === 'style-object' || key === 'styleObject') {
             acc.style = value;
             // To keep zoid as generic as possible, passing in the original prop name as well
-            acc[key] = value;
+            acc.styleObject = value;
         } else if (key.includes('-')) {
             acc[dasherizeToCamel(key)] = value;
         } else {

--- a/test/tests/drivers.js
+++ b/test/tests/drivers.js
@@ -304,6 +304,70 @@ describe('zoid drivers', () => {
         });
     });
 
+
+    it('should enter a component rendered with vue and accept prop styleObject and convert it to a style prop', () => {
+        return wrapPromise(({ expect }) => {
+
+            window.__component__ = () => {
+                return zoid.create({
+                    tag:    'test-render-vue-style-prop',
+                    url:    'mock://www.child.com/base/test/windows/child/index.htm',
+                    domain: 'mock://www.child.com'
+                });
+            };
+
+            if (!getBody()) {
+                throw new Error('Can not find getBody()');
+            }
+
+            const app = document.createElement('div');
+            const vueComponent = window.__component__().driver('vue', window.Vue);
+
+            if (!getBody()) {
+                throw new Error(`Expected getBody() to be present`);
+            }
+
+            getBody().appendChild(app);
+
+            new window.Vue({
+                render: expect('render', function render(createElement) : Object {
+                    return createElement(vueComponent, {
+                        attrs: {
+                            'styleObject': () => ({ color: 'red' }),
+                            'onLoad':       this.state.onLoad,
+                            'color':        this.state.color,
+                            'run':          this.state.run
+                        }
+                    });
+                }),
+                data() : Object {
+                    return {
+                        state: {
+                            onLoad: expect('onLoad', () => {
+                                // $FlowFixMe[object-this-reference]
+                                window.Vue.set(this.state, 'color', expect('color', color => {
+                                    if (color !== 'red') {
+                                        throw new Error(`Expected color to be 'red', got ${ color }`);
+                                    }
+                                }));
+                                
+                            }),
+                            run: expect('run', () => {
+                                return `
+                                    return window.xprops.onLoad().then(() => {
+                                        return window.xprops.style().then((style) => {
+                                            window.xprops.color(style.color);
+                                        });
+                                    });
+                                `;
+                            })
+                        }
+                    };
+                }
+            }).$mount(app);
+        });
+    });
+
     it('should enter a component rendered with angular 2 and call a prop', () => {
         return wrapPromise(({ expect }) => {
 


### PR DESCRIPTION
**Reasoning**

In Vue the prop name `style` is reserved thus if the user wants to pass in a style for the PayPal button this won't work, instead the user now can pass in a `style-object` prop with the desire styling for the button.
To keep Zoid generic, we are passing in the original prop name, so if Zoid is used for other application the user will received the expected prop name in the component.

**Change**
Added logic on the Vue driver to replace the prop name `styleObject` or `style-object` by a `style` prop.

Reference: https://vuejs.org/v2/guide/class-and-style.html#Object-Syntax-1

