### PR TITLE
Fixing broken demos for basic popup and missing script demo

### DIFF
--- a/demo/basic/popup/index.htm
+++ b/demo/basic/popup/index.htm
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/4.0.2/bootstrap-material-design.css" />
     <link rel="stylesheet" href="../../common/index.css" />
 
-    <script src="../../../node_modules/jsx-pragmatic/dist/jsx-pragmatic.js"></script>
+    <script src="https://unpkg.com/jsx-pragmatic@2.0.20/dist/jsx-pragmatic.js"></script>
     <script src="../../../dist/zoid.js"></script>
     <script src="./login.js"></script>
 </head>

--- a/demo/index.htm
+++ b/demo/index.htm
@@ -34,7 +34,6 @@
         <h2>framework demos</h2>
 
         <ul>
-            <li><a href="./frameworks/script/index.htm">script tag component</a></li>
             <li><a href="./frameworks/react/index.htm">react component</a></li>
             <li><a href="./frameworks/angular/index.htm">angular component</a></li>
             <li><a href="./frameworks/vue/index.htm">vue component</a></li>


### PR DESCRIPTION
While doing some reading of docs I noticed a couple non-functional demos. The popup demo is an easy fix, but I couldn't find a reference to the "script tag component" so just deleted that.

Not sure how to get this published to the krakenjs docs site, will need help with that.