### PR TITLE
Add Github Action to generate changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: "Changelog generation"
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{steps.github_release.outputs.changelog}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When generating (and pushing) a new tag, we are going to automatically create a new release with the proper changelog

An example of how this might look like can be found here: https://github.com/mikepenz/release-changelog-builder-action/releases/tag/v2.4.2

Also, keep in mind that for it to be able to automatically categorize the issues in the different "tabs", we need to use Github's tags on the PRs

Closes #108