### PR TITLE
fix: specify dimensions in iframe demo

### DIFF
--- a/demo/basic/iframe/login.js
+++ b/demo/basic/iframe/login.js
@@ -1,5 +1,9 @@
 
 window.MyLoginZoidComponent = zoid.create({
+    dimensions: {
+        width: '300px',
+        height: '150px',
+    },
 
     // The html tag used to render my component
 


### PR DESCRIPTION
If you go to https://krakenjs.com/zoid/demo/basic/iframe/index.htm, you'll see that the iframe login is missing.

This is because the dimensions aren't being passed, so the height and width are being set to undefined.

Passing the dimensions fixes the issue:

<img width="403" alt="Screen Shot 2021-10-20 at 3 59 27 PM" src="https://user-images.githubusercontent.com/2916945/138171208-83eea128-06c1-4b4f-902b-01f159c35cc9.png">

A broader question I have is whether or not `dimensions` should be a required attribute or not. Currently, it's not marked as required in the docs: https://github.com/krakenjs/zoid/blob/master/docs/api/create.md#dimensions--width--string-height--string-
