### PR TITLE
fix: ensure input props are merged in

### DIFF
--- a/src/parent/props.js
+++ b/src/parent/props.js
@@ -11,7 +11,7 @@ import type { ParentHelpers } from './index';
 export function extendProps<P, X>(propsDef : PropsDefinitionType<P, X>, existingProps : PropsType<P>, inputProps : PropsInputType<P>, helpers : ParentHelpers<P>, container : HTMLElement | void) {
     const { state, close, focus, event, onError } = helpers;
 
-    const newProps = { ...existingProps };
+    const newProps = { ...existingProps, ...inputProps };
 
     // $FlowFixMe
     eachProp(inputProps, propsDef, (key, propDef, value) => {

--- a/test/tests/props.js
+++ b/test/tests/props.js
@@ -87,6 +87,53 @@ describe('zoid props cases', () => {
         });
     });
 
+    it('should merge props definition with input props before passing to decorator', () => {
+        return wrapPromise(({ expect }) => {
+            window.__component__ = () => {
+                return zoid.create({
+                    tag:    'test-prop-value-container-url-param-bug',
+                    url:    'mock://www.child.com/base/test/windows/child/index.htm',
+                    domain: 'mock://www.child.com',
+                    props:  {
+                        account: {
+                            type:       'string',
+                            queryParam: false,
+                            required:   true,
+                            value:      () => undefined
+                        },
+                        testAccountParam: {
+                            type:       'string',
+                            queryParam: 'account',
+                            decorate:   ({ props }) => props.account,
+                            default:    () => '',
+                            required:   false
+                        },
+                        passFoo: {
+                            type:     'function',
+                            required: true
+                        }
+                    }
+                });
+            };
+
+            const component = window.__component__();
+            const instance = component({
+                run: () => `
+                    window.xprops.passFoo({ query: location.search });
+                `,
+                account: '123',
+                passFoo: expect('passFoo', ({ query }) => {
+                    if (query.indexOf(`account=123`) === -1) {
+                        throw new Error(`Expected account=123 in the url, but got ${query}`);
+                    }
+
+                })
+            });
+            
+            return instance.render(getBody());
+        });
+    });
+
     it('should render a component with a prop with a pre-defined value using container, and pass the value in the url', () => {
         return wrapPromise(({ expect }) => {
             const bodyWidth = getBody().offsetWidth;

--- a/test/tests/props.js
+++ b/test/tests/props.js
@@ -41,7 +41,7 @@ describe('zoid props cases', () => {
                     }
                 })
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -82,7 +82,7 @@ describe('zoid props cases', () => {
                     }
                 })
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -99,7 +99,9 @@ describe('zoid props cases', () => {
                             type:       'string',
                             queryParam: false,
                             required:   true,
-                            value:      () => undefined
+                            value:      ({ props }) => {
+                                return props.account;
+                            }
                         },
                         testAccountParam: {
                             type:       'string',
@@ -124,12 +126,12 @@ describe('zoid props cases', () => {
                 account: '123',
                 passFoo: expect('passFoo', ({ query }) => {
                     if (query.indexOf(`account=123`) === -1) {
-                        throw new Error(`Expected account=123 in the url, but got ${query}`);
+                        throw new Error(`Expected account=123 in the url, but got ${ query }`);
                     }
 
                 })
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -171,7 +173,7 @@ describe('zoid props cases', () => {
                     }
                 })
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -215,7 +217,7 @@ describe('zoid props cases', () => {
             });
 
             Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
-            
+
             const renderPromise = instance.render('#container-element');
 
             const container = document.createElement('div');
@@ -257,7 +259,7 @@ describe('zoid props cases', () => {
                     });
                 }
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -293,7 +295,7 @@ describe('zoid props cases', () => {
                     });
                 }
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -345,7 +347,7 @@ describe('zoid props cases', () => {
                     });
                 }
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -416,13 +418,13 @@ describe('zoid props cases', () => {
 
                 postRun: () => {
                     doExpect = true;
-    
+
                     return instance.updateProps({
                         meep: error('meepv2')
                     });
                 }
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -443,13 +445,13 @@ describe('zoid props cases', () => {
             return component({
 
                 customProp: expectedResult,
-    
+
                 foo: expect('foo', bar => {
                     if (bar !== expectedResult) {
                         throw new Error(`Expected bar to be 'bar', got ${ bar }`);
                     }
                 }),
-    
+
                 run: () => `
                     window.xprops.foo(window.xprops.customProp);
                 `
@@ -473,13 +475,13 @@ describe('zoid props cases', () => {
             return component({
 
                 customProp: expectedResult,
-    
+
                 foo: expect('foo', bar => {
                     if (bar !== expectedResult) {
                         throw new Error(`Expected bar to be 'bar', got ${ bar }`);
                     }
                 }),
-    
+
                 run: () => `
                     window.xprops.foo(window.xprops.customProp);
                 `
@@ -503,13 +505,13 @@ describe('zoid props cases', () => {
             return component({
 
                 customProp: expectedResult,
-    
+
                 foo: expect('foo', bar => {
                     if (bar !== expectedResult) {
                         throw new Error(`Expected bar to be 'bar', got ${ bar }`);
                     }
                 }),
-    
+
                 run: () => `
                     window.xprops.foo(window.xprops.customProp);
                 `
@@ -558,7 +560,7 @@ describe('zoid props cases', () => {
                     if (typeof result[3] !== 'function') {
                         throw new TypeError(`Object ${ JSON.stringify(result) } does not match expected ${ JSON.stringify(expectedResult) }`);
                     }
-                    
+
                     result[3]();
                 }),
 
@@ -610,7 +612,7 @@ describe('zoid props cases', () => {
                     if (typeof result.fn !== 'function') {
                         throw new TypeError(`Object ${ JSON.stringify(result) } does not match expected ${ JSON.stringify(expectedResult) }`);
                     }
-                    
+
                     result.fn();
                 }),
 
@@ -704,7 +706,7 @@ describe('zoid props cases', () => {
                     window.xprops.passProp(window.xprops.foo);
                 `
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -738,7 +740,7 @@ describe('zoid props cases', () => {
                     window.xprops.passProp(window.xprops.foo);
                 `
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -767,7 +769,7 @@ describe('zoid props cases', () => {
                     window.xprops.bar();
                 `
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -796,7 +798,7 @@ describe('zoid props cases', () => {
                     window.xprops.foo();
                 `
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -897,7 +899,7 @@ describe('zoid props cases', () => {
                     window.xprops.getQuery(window.location.search.slice(1));
                 `
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -990,7 +992,7 @@ describe('zoid props cases', () => {
                     window.xprops.getQuery(window.location.search.slice(1));
                 `
             });
-            
+
             return instance.render(getBody());
         });
     });
@@ -1082,7 +1084,7 @@ describe('zoid props cases', () => {
                     `;
                 }
             });
-            
+
             return instance.render(getBody());
         });
     });


### PR DESCRIPTION
Bug fix for messaging issue introduced in sdk version: 5.0.268

### Description
`paypal-messaging-components` has a prop def for `account` in which the value is passed in from `inputProps` in some cases and also `propDef.value` may be returning `undefined`. This causes an issue where decorators which read from that `inputProp` will receive the `undefined` value. In our case the decorator in messaging threw on an `undefined` value and that code is linked below.

### Root Cause
During a previous changeset in https://github.com/krakenjs/zoid/pull/376 the `extendProps` function was changed and no longer took into account merging `existingProps` & `inputProps`. Now later in the flow if a decorated prop requires a value from `inputProps` it won't be present.

### Messaging Component's Error
The decorator in `paypal-messaging-components` which received the `undefined` value for account is [here](https://github.com/paypal/paypal-messaging-components/blob/f0cd8d1e9b6dce5ad4602ad559e3f4f4824f10d5/src/zoid/message/component.js#L317). As you can see this decorator uses the `stringStartsWith` from `core-js` which unfortunately will throw on non string values. In this case we were passing in `undefined` as `inputProps` was not properly passed in and it took the `undefined` value from the original propsDef for account.

