### PR TITLE
Pass container to prop definitions when available (round 2)

### DIFF
--- a/docs/api/prop-definitions.md
+++ b/docs/api/prop-definitions.md
@@ -1,156 +1,205 @@
 # Prop Definitions
 
-## type `string`
+## type
 
-  The data-type expected for the prop
+`string`
 
-  - `'string'`
-  - `'number'`
-  - `'boolean'`
-  - `'object'`
-  - `'function'`
-  - `'array'`
+The data-type expected for the prop
 
-## required `boolean`
+- `'string'`
+- `'number'`
+- `'boolean'`
+- `'object'`
+- `'function'`
+- `'array'`
 
-  Whether or not the prop is mandatory. Defaults to `true`.
+## required
 
-  ```javascript
-  onLogin: {
-      type: 'function',
-      required: false
-  }
-  ```
+`boolean`
 
-## default `({ props }) => value`
+Whether or not the prop is mandatory. Defaults to `true`.
 
-  A function returning the default value for the prop, if none is passed
+```javascript
+onLogin: {
+    type: 'function',
+    required: false
+}
+```
 
-  ```javascript
-  email: {
-      type: 'string',
-      required: false,
-      default: function() {
-          return 'a@b.com';
-      }
-  }
-  ```
+## default
 
-## validate `({ value, props }) => void`
+```javascript
+({
+    props : Props,
+    state : Object,
+    close : () => Promise<undefined>,
+    focus : () => Promise<undefined>,
+    onError : (mixed) => Promise<undefined>,
+    container : HTMLElement | undefined,
+    event : Event
+}) => value
+```
 
-  A function to validate the passed value. Should throw an appropriate error if invalid.
+A function returning the default value for the prop, if none is passed
 
-  ```javascript
-  email: {
-      type: 'string',
-      validate: function({ value, props }) {
-          if (!value.match(/^.+@.+\..+$/)) {
-              throw new TypeError(`Expected email to be valid format`);
-          }
-      }
-  }
-  ```
+```javascript
+email: {
+    type: 'string',
+    required: false,
+    default: function() {
+        return 'a@b.com';
+    }
+}
+```
 
-## queryParam `boolean | string | (value) => string`
+## validate
 
-  Should a prop be passed in the url.
+`({ value, props }) => void`
 
-  ```javascript
-  email: {
-      type: 'string',
-      queryParam: true // ?email=foo@bar.com
-  }
-  ```
+A function to validate the passed value. Should throw an appropriate error if invalid.
 
-  If a string is set, this specifies the url param name which will be used. 
+```javascript
+email: {
+    type: 'string',
+    validate: function({ value, props }) {
+        if (!value.match(/^.+@.+\..+$/)) {
+            throw new TypeError(`Expected email to be valid format`);
+        }
+    }
+}
+```
 
-  ```javascript
-  email: {
-      type: 'string',
-      queryParam: 'user-email' // ?user-email=foo@bar.com
-  }
-  ```
+## queryParam
 
-  If a function is set, this is called to determine the url param which should be used.
+`boolean | string | (value) => string`
 
-  ```javascript
-  email: {
-      type: 'string',
-      queryParam: function({ value }) {
-          if (value.indexOf('@foo.com') !== -1) {
-              return 'foo-email'; // ?foo-email=person@foo.com
-          } else {
-              return 'generic-email'; // ?generic-email=person@whatever.com
-          }
-      }
-  }
-  ```
+Should a prop be passed in the url.
 
-## value `({ props }) => value`
+```javascript
+email: {
+    type: 'string',
+    queryParam: true // ?email=foo@bar.com
+}
+```
 
-  The value for the prop, if it should be statically defined at component creation time
+If a string is set, this specifies the url param name which will be used. 
 
-  ```javascript
-  userAgent: {
-      type: 'string',
-      value() {
-          return window.navigator.userAgent;
-      }
-  }
-  ```
+```javascript
+email: {
+    type: 'string',
+    queryParam: 'user-email' // ?user-email=foo@bar.com
+}
+```
 
-## decorate `({ value, props }) => value`
+If a function is set, this is called to determine the url param which should be used.
 
-  A function used to decorate the prop at render-time. Called with the value of the prop, should return the new value.
+```javascript
+email: {
+    type: 'string',
+    queryParam: function({ value }) {
+        if (value.indexOf('@foo.com') !== -1) {
+            return 'foo-email'; // ?foo-email=person@foo.com
+        } else {
+            return 'generic-email'; // ?generic-email=person@whatever.com
+        }
+    }
+}
+```
 
-  ```javascript
-  onLogin: {
-      type: 'function',
-      decorate(original) {
-          return function() {
-              console.log('User logged in!');
-              return original.apply(this, arguments);
-          };
-      }
-  }
-  ```
+## value
 
-## serialization `string`
+```javascript
+({
+    props : Props,
+    state : Object,
+    close : () => Promise<undefined>,
+    focus : () => Promise<undefined>,
+    onError : (mixed) => Promise<undefined>,
+    container : HTMLElement | undefined,
+    event : Event
+}) => value
+```
 
-  If `json`, the prop will be JSON stringified before being inserted into the url
+The value for the prop, if it should be statically defined at component creation time
 
-  ```javascript
-  user: {
-      type: 'object',
-      serialization: 'json' // ?user={"name":"Zippy","age":34}
-  }
-  ```
+```javascript
+userAgent: {
+    type: 'string',
+    value() {
+        return window.navigator.userAgent;
+    }
+}
+```
 
-  If `dotify` the prop will be converted to dot-notation.
+## decorate
 
-  ```javascript
-  user: {
-      type: 'object',
-      serialization: 'dotify' // ?user.name=Zippy&user.age=34
-  }
-  ```
+```javascript
+({
+    props : Props,
+    state : Object,
+    close : () => Promise<undefined>,
+    focus : () => Promise<undefined>,
+    onError : (mixed) => Promise<undefined>,
+    container : HTMLElement | undefined,
+    event : Event,
+    value : Value
+}) => value
+```
 
-  If `base64`, the prop will be JSON stringified then base64 encoded before being inserted into the url
+A function used to decorate the prop at render-time. Called with the value of the prop, should return the new value.
 
-  ```javascript
-  user: {
-      type: 'object',
-      serialization: 'base64' // ?user=eyJuYW1lIjoiWmlwcHkiLCJhZ2UiOjM0fQ==
-  }
-  ```
+```javascript
+onLogin: {
+    type: 'function',
+    decorate(original) {
+        return function() {
+            console.log('User logged in!');
+            return original.apply(this, arguments);
+        };
+    }
+}
+```
 
-## alias `string`
+## serialization
 
-  An aliased name for the prop
+`string`
 
-  ```javascript
-  onLogin: {
-      type: 'function',
-      alias: 'onUserLogin'
-  }
-  ```
+If `json`, the prop will be JSON stringified before being inserted into the url
+
+```javascript
+user: {
+    type: 'object',
+    serialization: 'json' // ?user={"name":"Zippy","age":34}
+}
+```
+
+If `dotify` the prop will be converted to dot-notation.
+
+```javascript
+user: {
+    type: 'object',
+    serialization: 'dotify' // ?user.name=Zippy&user.age=34
+}
+```
+
+If `base64`, the prop will be JSON stringified then base64 encoded before being inserted into the url
+
+```javascript
+user: {
+    type: 'object',
+    serialization: 'base64' // ?user=eyJuYW1lIjoiWmlwcHkiLCJhZ2UiOjM0fQ==
+}
+```
+
+## alias
+
+`string`
+
+An aliased name for the prop
+
+```javascript
+onLogin: {
+    type: 'function',
+    alias: 'onUserLogin'
+}
+```

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -16,7 +16,7 @@ import { ZOID, POST_MESSAGE, CONTEXT, EVENT, METHOD,
 import { getGlobal, getProxyObject, crossDomainSerialize, buildChildWindowName, type ProxyObject } from '../lib';
 import type { PropsInputType, PropsType } from '../component/props';
 import type { ChildExportsType } from '../child';
-import type { CssDimensionsType } from '../types';
+import type { CssDimensionsType, ContainerReferenceType } from '../types';
 import type { NormalizedComponentOptionsType, AttributesType } from '../component';
 
 import { serializeProps, extendProps } from './props';
@@ -102,7 +102,7 @@ type RenderContainerOptions = {|
 
 type ResolveInitPromise = () => ZalgoPromise<void>;
 type RejectInitPromise = (mixed) => ZalgoPromise<void>;
-type GetProxyContainer = (container : string | HTMLElement) => ZalgoPromise<ProxyObject<HTMLElement>>;
+type GetProxyContainer = (container : ContainerReferenceType) => ZalgoPromise<ProxyObject<HTMLElement>>;
 type Show = () => ZalgoPromise<void>;
 type Hide = () => ZalgoPromise<void>;
 type Close = () => ZalgoPromise<void>;
@@ -159,7 +159,7 @@ type DelegateOverrides = {|
 
 type RenderOptions = {|
     target : CrossDomainWindowType,
-    container : string | HTMLElement,
+    container : ContainerReferenceType,
     context : $Values<typeof CONTEXT>,
     rerender : Rerender
 |};
@@ -205,6 +205,7 @@ export function parentComponent<P, X, C>({ uid, options, overrides = getDefaultO
     let currentProxyContainer : ?ProxyObject<HTMLElement>;
     let childComponent : ?ChildExportsType<P>;
     let currentChildDomain : ?string;
+    let currentContainer : HTMLElement | void;
 
     const onErrorOverride : ?OnError = overrides.onError;
     let getProxyContainerOverride : ?GetProxyContainer = overrides.getProxyContainer;
@@ -331,22 +332,6 @@ export function parentComponent<P, X, C>({ uid, options, overrides = getDefaultO
             }
 
             return new ProxyWindow({ send });
-        });
-    };
-
-    const getProxyContainer : GetProxyContainer = (container : string | HTMLElement) : ZalgoPromise<ProxyObject<HTMLElement>> => {
-        if (getProxyContainerOverride) {
-            return getProxyContainerOverride(container);
-        }
-
-        return ZalgoPromise.try(() => {
-            return elementReady(container);
-        }).then(containerElement => {
-            if (isShadowElement(containerElement)) {
-                containerElement = insertShadowSlot(containerElement);
-            }
-
-            return getProxyObject(containerElement);
         });
     };
 
@@ -926,17 +911,23 @@ export function parentComponent<P, X, C>({ uid, options, overrides = getDefaultO
 
     const getProps = () => props;
 
-    const setProps = (newProps : PropsInputType<P>, isUpdate? : boolean = false) => {
+    const getDefaultPropsInput = () : PropsInputType<P> => {
+        // $FlowFixMe
+        return {};
+    };
+
+    const setProps = (newProps : PropsInputType<P> = getDefaultPropsInput()) => {
         if (__DEBUG__ && validate) {
             validate({ props: newProps });
         }
 
+        const container = currentContainer;
         const helpers = getHelpers();
-        extendProps(propsDef, props, newProps, helpers, isUpdate);
+        extendProps(propsDef, props, newProps, helpers, container);
     };
 
     const updateProps = (newProps : PropsInputType<P>) : ZalgoPromise<void> => {
-        setProps(newProps, true);
+        setProps(newProps);
 
         return initPromise.then(() => {
             const child = childComponent;
@@ -956,6 +947,23 @@ export function parentComponent<P, X, C>({ uid, options, overrides = getDefaultO
                     });
                 });
             });
+        });
+    };
+
+    const getProxyContainer : GetProxyContainer = (container : ContainerReferenceType) : ZalgoPromise<ProxyObject<HTMLElement>> => {
+        if (getProxyContainerOverride) {
+            return getProxyContainerOverride(container);
+        }
+
+        return ZalgoPromise.try(() => {
+            return elementReady(container);
+        }).then(containerElement => {
+            if (isShadowElement(containerElement)) {
+                containerElement = insertShadowSlot(containerElement);
+            }
+
+            currentContainer = containerElement;
+            return getProxyObject(containerElement);
         });
     };
 
@@ -1017,7 +1025,7 @@ export function parentComponent<P, X, C>({ uid, options, overrides = getDefaultO
         });
     };
 
-    const checkAllowRender = (target : CrossDomainWindowType, childDomainMatch : DomainMatcher, container : string | HTMLElement) => {
+    const checkAllowRender = (target : CrossDomainWindowType, childDomainMatch : DomainMatcher, container : ContainerReferenceType) => {
         if (target === window) {
             return;
         }
@@ -1058,12 +1066,19 @@ export function parentComponent<P, X, C>({ uid, options, overrides = getDefaultO
 
             const watchForUnloadPromise = watchForUnload();
             
-            const buildUrlPromise = buildUrl();
             const buildBodyPromise = buildBody();
             const onRenderPromise = event.trigger(EVENT.RENDER);
 
             const getProxyContainerPromise = getProxyContainer(container);
             const getProxyWindowPromise = getProxyWindow();
+
+            const finalSetPropsPromise = getProxyContainerPromise.then(() => {
+                return setProps();
+            });
+
+            const buildUrlPromise = finalSetPropsPromise.then(() => {
+                return buildUrl();
+            });
 
             const buildWindowNamePromise = getProxyWindowPromise.then(proxyWin => {
                 return buildWindowName({ proxyWin, initialChildDomain, childDomainMatch, target, context });
@@ -1143,7 +1158,7 @@ export function parentComponent<P, X, C>({ uid, options, overrides = getDefaultO
             return ZalgoPromise.hash({
                 initPromise, buildUrlPromise, onRenderPromise, getProxyContainerPromise, openFramePromise, openPrerenderFramePromise, renderContainerPromise, openPromise,
                 openPrerenderPromise, setStatePromise, prerenderPromise, loadUrlPromise, buildWindowNamePromise, setWindowNamePromise, watchForClosePromise, onDisplayPromise,
-                openBridgePromise, runTimeoutPromise, onRenderedPromise, delegatePromise, watchForUnloadPromise
+                openBridgePromise, runTimeoutPromise, onRenderedPromise, delegatePromise, watchForUnloadPromise, finalSetPropsPromise
             });
             
         }).catch(err => {

--- a/src/types.js
+++ b/src/types.js
@@ -18,3 +18,5 @@ export type CancelableType = {|
 |};
 
 export type StringMatcherType = string | $ReadOnlyArray<string> | RegExp;
+
+export type ContainerReferenceType = string | HTMLElement;

--- a/test/tests/props.js
+++ b/test/tests/props.js
@@ -1,13 +1,185 @@
 /* @flow */
 /* eslint max-lines: off */
 
-import { wrapPromise, noop, parseQuery, destroyElement } from 'belter/src';
+import { wrapPromise, noop, parseQuery, destroyElement, getElement } from 'belter/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 
 import { onWindowOpen, getBody } from '../common';
 import { zoid } from '../zoid';
 
 describe('zoid props cases', () => {
+
+    it('should render a component with a prop with a pre-defined value', () => {
+        return wrapPromise(({ expect }) => {
+
+            window.__component__ = () => {
+                return zoid.create({
+                    tag:    'test-prop-value',
+                    url:    'mock://www.child.com/base/test/windows/child/index.htm',
+                    domain: 'mock://www.child.com',
+                    props:  {
+                        foo: {
+                            type:  'string',
+                            value: () => 'bar'
+                        },
+                        passFoo: {
+                            type:     'function',
+                            required: true
+                        }
+                    }
+                });
+            };
+
+            const component = window.__component__();
+            const instance = component({
+                run: () => `
+                    window.xprops.passFoo({ foo: xprops.foo });
+                `,
+                passFoo: expect('passFoo', ({ foo }) => {
+                    if (foo !== 'bar') {
+                        throw new Error(`Expected prop to have the correct value; got ${ foo }`);
+                    }
+                })
+            });
+            
+            return instance.render(getBody());
+        });
+    });
+
+    it('should render a component with a prop with a pre-defined value using container', () => {
+        return wrapPromise(({ expect }) => {
+            const bodyWidth = getBody().offsetWidth;
+
+            window.__component__ = () => {
+                return zoid.create({
+                    tag:    'test-prop-value-container',
+                    url:    'mock://www.child.com/base/test/windows/child/index.htm',
+                    domain: 'mock://www.child.com',
+                    props:  {
+                        foo: {
+                            type:     'number',
+                            required: false,
+                            value:    ({ container }) => {
+                                return container?.offsetWidth;
+                            }
+                        },
+                        passFoo: {
+                            type:     'function',
+                            required: true
+                        }
+                    }
+                });
+            };
+
+            const component = window.__component__();
+            const instance = component({
+                run: () => `
+                    window.xprops.passFoo({ foo: xprops.foo });
+                `,
+                passFoo: expect('passFoo', ({ foo }) => {
+                    if (foo !== bodyWidth) {
+                        throw new Error(`Expected prop to have the correct value; got ${ foo }`);
+                    }
+                })
+            });
+            
+            return instance.render(getBody());
+        });
+    });
+
+    it('should render a component with a prop with a pre-defined value using container, and pass the value in the url', () => {
+        return wrapPromise(({ expect }) => {
+            const bodyWidth = getBody().offsetWidth;
+
+            window.__component__ = () => {
+                return zoid.create({
+                    tag:    'test-prop-value-container-url-param',
+                    url:    'mock://www.child.com/base/test/windows/child/index.htm',
+                    domain: 'mock://www.child.com',
+                    props:  {
+                        foo: {
+                            type:     'number',
+                            required: false,
+                            value:    ({ container }) => {
+                                return container ? getElement(container)?.offsetWidth : null;
+                            },
+                            queryParam: true
+                        },
+                        passFoo: {
+                            type:     'function',
+                            required: true
+                        }
+                    }
+                });
+            };
+
+            const component = window.__component__();
+            const instance = component({
+                run: () => `
+                    window.xprops.passFoo({ query: location.search });
+                `,
+                passFoo: expect('passFoo', ({ query }) => {
+                    if (query.indexOf(`foo=${ bodyWidth }`) === -1) {
+                        throw new Error(`Expected foo=${ bodyWidth } in the url`);
+                    }
+                })
+            });
+            
+            return instance.render(getBody());
+        });
+    });
+
+    it('should render a component with a prop with a pre-defined value using container, and pass the value in the url, with a lazy element', () => {
+        return wrapPromise(({ expect }) => {
+            const bodyWidth = getBody().offsetWidth;
+
+            window.__component__ = () => {
+                return zoid.create({
+                    tag:    'test-prop-value-container-url-param-element-not-ready',
+                    url:    'mock://www.child.com/base/test/windows/child/index.htm',
+                    domain: 'mock://www.child.com',
+                    props:  {
+                        foo: {
+                            type:     'number',
+                            required: false,
+                            value:    ({ container }) => {
+                                return container ? getElement(container)?.offsetWidth : null;
+                            },
+                            queryParam: true
+                        },
+                        passFoo: {
+                            type:     'function',
+                            required: true
+                        }
+                    }
+                });
+            };
+
+            const component = window.__component__();
+            const instance = component({
+                run: () => `
+                    window.xprops.passFoo({ query: location.search });
+                `,
+                passFoo: expect('passFoo', ({ query }) => {
+                    if (query.indexOf(`foo=${ bodyWidth }`) === -1) {
+                        throw new Error(`Expected foo=${ bodyWidth } in the url`);
+                    }
+                })
+            });
+
+            Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+            
+            const renderPromise = instance.render('#container-element');
+
+            const container = document.createElement('div');
+            container.setAttribute('id', 'container-element');
+            getBody().appendChild(container);
+
+            Object.defineProperty(document, 'readyState', { value: 'ready', configurable: true });
+
+            return renderPromise;
+        });
+    });
 
     it('should enter a component, update a prop, and call a prop', () => {
         return wrapPromise(({ expect }) => {
@@ -189,7 +361,7 @@ describe('zoid props cases', () => {
                                     if (err || !result) {
                                         return onError(err);
                                     }
-
+                    
                                     return value(true);
                                 };
                             }


### PR DESCRIPTION
### Description
📖  This PR contains the latest commit merged with the @bluepnume commit: 89342cc237cd865a73285e5e423ec2e44c2ee437.
This PR contains a bug fix related to the decorate functions not working properly due to the override reference after the container parameter was introduced.

👀  The problem was related to this function `setProps`. Now we're calling that function twice in the zoid code. One in the instance creation step and two in the render process. That causes a reference function overriding in this file `parent/props.js` in the `extendProps` utils function.

If we call twice this`propDef.decorate` function, that will return a `new` function, meaning the second time we call the `propDef.decorate` won't be the original defined function, instead will have a reference to the result of the execution of the decorated function.

### Why are we making these changes? 
We're making this change to solve this failing test case: `should allow decorated functions to change their signature from the original value callback prop`. After the new `container` parameter was added to the decorator this test starts failing.

### Reproduction Steps
If we set any kind of decorate logic that uses the `value` argument, the code won't work. 
You can use this logic from the failing test case:

🧪  
```
 decorate: ({ value, onError }) => {
    return (err, result) => {
        if (err || !result) {
            return onError(err);
        }

        return value(true);
    };
}

 window.xprops.onSuccess(null, {success: true});
```
:boom: The first time the function is called, the `err` argument will be equal to: `null` and `result` argument equal to: `{success: true}`. In the second call, the `err` argument will be equal to: `true` and `result` argument equal to: `undefined`.

🤔 Could be a good idea to use `Proxy`objects, or maybe `Object.setPrototypeOf` to have a better control over what we're modifying in the `propDef`. Both of them aren't support in Internet Explorer 💣 
