### PR TITLE
fix: avoid throwing errors if container is no longer in page

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,7 +9,7 @@ export const POST_MESSAGE = {
   ALLOW_DELEGATE: `${ZOID}_allow_delegate`,
 };
 
-export const RENDER_ERRORS = {
+export const COMPONENT_ERROR = {
   NAVIGATED_AWAY: "Window navigated away",
   COMPONENT_DESTROYED: "Component destroyed",
   COMPONENT_CLOSED: "Component closed",

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,13 @@ export const POST_MESSAGE = {
   ALLOW_DELEGATE: `${ZOID}_allow_delegate`,
 };
 
+export const RENDER_ERRORS = {
+  NAVIGATED_AWAY: "Window navigated away",
+  COMPONENT_DESTROYED: "Component destroyed",
+  COMPONENT_CLOSED: "Component closed",
+  WINDOW_CLOSED: "Detected component window close",
+};
+
 export const PROP_TYPE = {
   STRING: ("string": "string"),
   OBJECT: ("object": "object"),

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,8 @@ export const COMPONENT_ERROR = {
   COMPONENT_DESTROYED: "Component destroyed",
   COMPONENT_CLOSED: "Component closed",
   WINDOW_CLOSED: "Detected component window close",
+  POPUP_CLOSE: "Detected popup close",
+  IFRAME_CLOSE: "Detected iframe close",
 };
 
 export const PROP_TYPE = {

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -317,7 +317,6 @@ export function parentComponent<P, X, C>({
   let childComponent: ?ChildExportsType<P>;
   let currentChildDomain: ?string;
   let currentContainer: HTMLElement | void;
-  let isRenderFinished: boolean = false;
 
   const onErrorOverride: ?OnError = overrides.onError;
   let getProxyContainerOverride: ?GetProxyContainer =
@@ -1619,7 +1618,6 @@ export function parentComponent<P, X, C>({
       });
 
       const onRenderedPromise = initPromise.then(() => {
-        isRenderFinished = true;
         return event.trigger(EVENT.RENDERED);
       });
 

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -316,7 +316,7 @@ export function parentComponent<P, X, C>({
   let currentProxyContainer: ?ProxyObject<HTMLElement>;
   let childComponent: ?ChildExportsType<P>;
   let currentChildDomain: ?string;
-  let currentContainer: HTMLElement | void;
+  let currentContainer: HTMLElement;
 
   const onErrorOverride: ?OnError = overrides.onError;
   let getProxyContainerOverride: ?GetProxyContainer =

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -65,6 +65,7 @@ import {
   METHOD,
   WINDOW_REFERENCE,
   DEFAULT_DIMENSIONS,
+  RENDER_ERRORS,
 } from "../constants";
 import {
   getGlobal,
@@ -729,12 +730,11 @@ export function parentComponent<P, X, C>({
         return clean.all(err);
       })
       .then(() => {
-        const error = err || new Error("Component destroyed");
+        const error = err || new Error(RENDER_ERRORS.COMPONENT_DESTROYED);
         if (
           isElementClosed(currentContainer) ||
-          error.message === "Window navigated away"
+          error.message === RENDER_ERRORS.NAVIGATED_AWAY
         ) {
-          console.warn(error);
           initPromise.resolve();
         } else {
           initPromise.asyncReject(error);
@@ -758,7 +758,7 @@ export function parentComponent<P, X, C>({
       return ZalgoPromise.try(() => {
         return event.trigger(EVENT.CLOSE);
       }).then(() => {
-        return destroy(err || new Error(`Component closed`));
+        return destroy(err || new Error(RENDER_ERRORS.COMPONENT_CLOSED));
       });
     });
   });
@@ -832,7 +832,7 @@ export function parentComponent<P, X, C>({
         window,
         "unload",
         once(() => {
-          destroy(new Error(`Window navigated away`));
+          destroy(new Error(RENDER_ERRORS.NAVIGATED_AWAY));
         })
       );
 
@@ -879,7 +879,7 @@ export function parentComponent<P, X, C>({
       .then((isClosed) => {
         if (isClosed) {
           closed = true;
-          return close(new Error(`Detected component window close`));
+          return close(new Error(RENDER_ERRORS.WINDOW_CLOSED));
         }
 
         return ZalgoPromise.delay(200)
@@ -887,7 +887,7 @@ export function parentComponent<P, X, C>({
           .then((secondIsClosed) => {
             if (secondIsClosed) {
               closed = true;
-              return close(new Error(`Detected component window close`));
+              return close(new Error(RENDER_ERRORS.WINDOW_CLOSED));
             }
           });
       })

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -729,7 +729,16 @@ export function parentComponent<P, X, C>({
         return clean.all(err);
       })
       .then(() => {
-        initPromise.asyncReject(err || new Error("Component destroyed"));
+        const error = err || new Error("Component destroyed");
+        if (
+          isElementClosed(currentContainer) ||
+          error.message === "Window navigated away"
+        ) {
+          console.warn(error);
+          initPromise.resolve();
+        } else {
+          initPromise.asyncReject(error);
+        }
       });
   };
 

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -317,7 +317,7 @@ export function parentComponent<P, X, C>({
   let childComponent: ?ChildExportsType<P>;
   let currentChildDomain: ?string;
   let currentContainer: HTMLElement | void;
-  let isSecondRenderFinished: boolean = false;
+  let isRenderFinished: boolean = false;
 
   const onErrorOverride: ?OnError = overrides.onError;
   let getProxyContainerOverride: ?GetProxyContainer =
@@ -736,7 +736,6 @@ export function parentComponent<P, X, C>({
           (currentContainer && isElementClosed(currentContainer)) ||
           error.message === COMPONENT_ERROR.NAVIGATED_AWAY
         ) {
-          console.warn(error);
           initPromise.resolve();
         } else {
           initPromise.asyncReject(error);
@@ -1620,7 +1619,7 @@ export function parentComponent<P, X, C>({
       });
 
       const onRenderedPromise = initPromise.then(() => {
-        isSecondRenderFinished = true;
+        isRenderFinished = true;
         return event.trigger(EVENT.RENDERED);
       });
 

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -736,6 +736,7 @@ export function parentComponent<P, X, C>({
           (currentContainer && isElementClosed(currentContainer)) ||
           error.message === COMPONENT_ERROR.NAVIGATED_AWAY
         ) {
+          console.warn(error);
           initPromise.resolve();
         } else {
           initPromise.asyncReject(error);
@@ -863,15 +864,8 @@ export function parentComponent<P, X, C>({
       })
       .then((isClosed) => {
         if (!cancelled) {
-          if (context === CONTEXT.POPUP && isClosed) {
-            return close(new Error(COMPONENT_ERROR.POPUP_CLOSE));
-          } else if (
-            context === CONTEXT.IFRAME &&
-            isClosed &&
-            ((currentContainer && isElementClosed(currentContainer)) ||
-              isSecondRenderFinished)
-          ) {
-            return close(new Error(COMPONENT_ERROR.IFRAME_CLOSE));
+          if (isClosed) {
+            return close(new Error(`Detected ${context} close`));
           } else {
             return watchForClose(proxyWin, context);
           }

--- a/test/tests/error.js
+++ b/test/tests/error.js
@@ -330,9 +330,9 @@ describe("zoid error cases", () => {
     );
   });
 
-  it("should call onclose when an iframe is closed by someone other than zoid during render", () => {
+  it("should error out when iframe is closed by someone other than zoid during render", () => {
     return wrapPromise(
-      ({ expect, avoid }) => {
+      ({ expect }) => {
         window.__component__ = () => {
           return zoid.create({
             tag: "test-onclose-iframe-closed-during-render",
@@ -343,17 +343,13 @@ describe("zoid error cases", () => {
 
         onWindowOpen().then(
           expect("onWindowOpen", ({ win: openedWindow }) => {
-            setTimeout(() => {
-              destroyElement(openedWindow.frameElement);
-            }, 1);
+            destroyElement(openedWindow.frameElement);
           })
         );
 
         const component = window.__component__();
         return component({
-          onClose: expect("onClose"),
-          onError: avoid("onError"),
-          onDestroy: expect("onDestroy"),
+          onError: expect("onError"),
         })
           .render("body", zoid.CONTEXT.IFRAME)
           .catch(expect("catch"));
@@ -587,25 +583,6 @@ describe("zoid error cases", () => {
       return ZalgoPromise.try(() => {
         component.driver("meep", {});
       }).catch(expect("catch"));
-    });
-  });
-
-  it("should error out where the domain is an invalid regex", () => {
-    return wrapPromise(({ expect }) => {
-      window.__component__ = () => {
-        return zoid.create({
-          tag: "test-render-domain-invalid-regex",
-          url: "mock://www.child.com/base/test/windows/child/index.htm",
-          domain: /^mock:\/\/www\.meep\.com$/,
-        });
-      };
-
-      const component = window.__component__();
-      return component({
-        onDestroy: expect("onDestroy"),
-      })
-        .render(getBody())
-        .catch(expect("catch"));
     });
   });
 

--- a/test/tests/remove.jsx
+++ b/test/tests/remove.jsx
@@ -102,4 +102,63 @@ describe("zoid remove cases", () => {
         });
     });
   });
+
+  it("should not throw an error when parent container is removed before render completes", () => {
+    return wrapPromise(() => {
+      const { container } = getContainer();
+
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-remove-before-render-complete",
+          url: () => "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+        });
+      };
+
+      const component = window.__component__();
+      const onRenderedPromise = new ZalgoPromise();
+      const onClosePromise = new ZalgoPromise();
+
+      const renderPromise = component({
+        onRendered: () => onRenderedPromise.resolve(),
+        onClose: () => onClosePromise.resolve(),
+      }).render(container);
+
+      // manually remove before render completes
+      container.remove();
+
+      return renderPromise.then(() => {
+        ZalgoPromise.delay(5);
+      });
+    });
+  });
+
+  it("should not throw an error when window navigates away before render completes", () => {
+    return wrapPromise(() => {
+      const { container } = getContainer();
+
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-navigation-before-render-complete",
+          url: () => "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+        });
+      };
+
+      const component = window.__component__();
+      const onRenderedPromise = new ZalgoPromise();
+      const onClosePromise = new ZalgoPromise();
+
+      const renderPromise = component({
+        onRendered: () => onRenderedPromise.resolve(),
+        onClose: () => onClosePromise.resolve(),
+      }).render(container);
+
+      // manually reload window before render completes
+      window.dispatchEvent(new Event("unload"));
+      return renderPromise.then(() => {
+        ZalgoPromise.delay(5);
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description

We have identified a few errors that zoid throws that cannot be caught by the implementation code (`render.catch() `and `close.catch()`) during asynchronous dismounts. Although this can occur in every webpage, it's primarily an issue when using React as seen here: [Issue #334](https://github.com/krakenjs/zoid/issues/334)

With this change, we first check if the container element has been removed from the DOM or the user has navigated away from the page mid-render. In these scenarios we should avoid throwing errors.

Here are 3 examples:
https://github.com/krakenjs/zoid/blob/main/src/parent/parent.js#L857
https://github.com/krakenjs/zoid/blob/main/src/parent/parent.js#L826
https://github.com/krakenjs/zoid/blob/main/src/parent/parent.js#L1172

These 3 error flows eventually cause the promise to be rejected since the render was never completed, and an error to be displayed on the console: https://github.com/krakenjs/zoid/blob/main/src/parent/parent.js#L732

### Reproduction Steps (if applicable)

To reproduce the `Window navigated away` error, open Chrome developer tools and persist logs. Call `paypalButtons.render('container-selector')` and then refresh the window or navigate to a different URL before second render is finished.

To reproduce `Component closed` or `Detected container element removed from DOM`, Call `paypalButtons.render('container-selector')` and then immediately remove the container selector before second render is finished.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

https://paypal.atlassian.net/browse/LI-7432