### PR TITLE
fix: only throwing errors for major version changes

### DIFF
--- a/src/child/child.js
+++ b/src/child/child.js
@@ -74,6 +74,10 @@ function destroy(): ZalgoPromise<void> {
   });
 }
 
+function hasMajorVersionChanged(version1: string, version2: string): boolean {
+  return version1.split("_")[0] !== version2.split("_")[0];
+}
+
 export type ChildComponent<P, X> = {|
   getProps: () => ChildPropsType<P, X>,
   init: () => ZalgoPromise<void>,
@@ -100,7 +104,7 @@ export function childComponent<P, X, C>(
     props: initialProps,
   } = payload;
 
-  if (version !== __ZOID__.__VERSION__) {
+  if (hasMajorVersionChanged(version, __ZOID__.__VERSION__)) {
     throw new Error(
       `Parent window has zoid version ${version}, child window has version ${__ZOID__.__VERSION__}`
     );

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -74,7 +74,7 @@ function destroy(): ZalgoPromise<void> {
   });
 }
 
-// This function will only compare the first numerical value,
+// Compares the first numerical value of the parent and child versions of zoid,
 // ensuring that an error is only thrown when major versions of Zoid are released.
 // Additionally, zoid version strings should be in snake_case format (10_1_0, 10_2_0, 11_0_0, etc.)
 function versionCompatabilityCheck(

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -113,8 +113,6 @@ export function childComponent<P, X, C>(
     throw new Error(
       `Parent window has zoid version ${version}, child window has version ${__ZOID__.__VERSION__}`
     );
-  } else {
-    console.log("passed regex tests");
   }
 
   const {

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -74,13 +74,20 @@ function destroy(): ZalgoPromise<void> {
   });
 }
 
-// zoid version strings should be in snake_case format (10_1_0, 10_2_0, 11_0_0, etc.)
-// since it is saved on the window object as a key. This function will compare the first numerical value
-// that should only change during major changes.
-function hasMajorVersionChanged(version1: string, version2: string): boolean {
-  if (/_/.test(version1) && /_/.test(version2)) {
-    return version1.split("_")[0] !== version2.split("_")[0];
+// This function will only compare the first numerical value,
+// ensuring that an error is only thrown when major versions of Zoid are released.
+// Additionally, zoid version strings should be in snake_case format (10_1_0, 10_2_0, 11_0_0, etc.)
+function versionCompatabilityCheck(
+  version1: string,
+  version2: string
+): boolean {
+  if (!/_/.test(version1) || !/_/.test(version2)) {
+    throw new Error(
+      `Versions are in an invalid format (${version1}, ${version2})`
+    );
   }
+
+  return version1.split("_")[0] === version2.split("_")[0];
 }
 
 export type ChildComponent<P, X> = {|
@@ -109,7 +116,7 @@ export function childComponent<P, X, C>(
     props: initialProps,
   } = payload;
 
-  if (hasMajorVersionChanged(version, __ZOID__.__VERSION__)) {
+  if (!versionCompatabilityCheck(version, __ZOID__.__VERSION__)) {
     throw new Error(
       `Parent window has zoid version ${version}, child window has version ${__ZOID__.__VERSION__}`
     );

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -74,8 +74,13 @@ function destroy(): ZalgoPromise<void> {
   });
 }
 
+// zoid version strings should be in snake_case format (10_1_0, 10_2_0, 11_0_0, etc.)
+// since it is saved on the window object as a key. This function will compare the first numerical value
+// that should only change during major changes.
 function hasMajorVersionChanged(version1: string, version2: string): boolean {
-  return version1.split("_")[0] !== version2.split("_")[0];
+  if (/_/.test(version1) && /_/.test(version2)) {
+    return version1.split("_")[0] !== version2.split("_")[0];
+  }
 }
 
 export type ChildComponent<P, X> = {|
@@ -108,6 +113,8 @@ export function childComponent<P, X, C>(
     throw new Error(
       `Parent window has zoid version ${version}, child window has version ${__ZOID__.__VERSION__}`
     );
+  } else {
+    console.log("passed regex tests");
   }
 
   const {

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -75,7 +75,7 @@ function destroy(): ZalgoPromise<void> {
 }
 
 // Compares the first numerical value of the parent and child versions of zoid,
-// ensuring that an error is only thrown when major versions of Zoid are released.
+// ensuring that an error is only thrown when major versions of Zoid do not match.
 // Additionally, zoid version strings should be in snake_case format (10_1_0, 10_2_0, 11_0_0, etc.)
 function versionCompatabilityCheck(
   version1: string,


### PR DESCRIPTION
### Description

We currently throw an error when the Zoid version doesn't strictly match. This change will only check for major version upgrades before throwing an error, patches and minor changes will be allowed to be different.