### PR TITLE
Iframe refactor

### DIFF
--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -864,26 +864,23 @@ export function parentComponent<P, X, C>({
       })
       .then((isClosed) => {
         if (!cancelled) {
-          if (isClosed) {
-            if (context === CONTEXT.POPUP) {
-              return close(new Error(COMPONENT_ERROR.POPUP_CLOSE));
-            }
-
-            const isCurrentContainerClosed: boolean = Boolean(
-              currentContainer && isElementClosed(currentContainer)
-            );
-
-            if (
-              context === CONTEXT.IFRAME &&
-              (isCurrentContainerClosed || isRenderFinished)
-            ) {
-              return close(new Error(COMPONENT_ERROR.IFRAME_CLOSE));
-            } else {
-              return watchForClose(proxyWin, context);
-            }
-          } else {
-            return watchForClose(proxyWin, context);
+          if (context === CONTEXT.POPUP && isClosed) {
+            return close(new Error(COMPONENT_ERROR.POPUP_CLOSE));
           }
+
+          const isCurrentContainerClosed: boolean = Boolean(
+            currentContainer && isElementClosed(currentContainer)
+          );
+
+          if (
+            context === CONTEXT.IFRAME &&
+            isClosed &&
+            (isCurrentContainerClosed || isRenderFinished)
+          ) {
+            return close(new Error(COMPONENT_ERROR.IFRAME_CLOSE));
+          }
+
+          return watchForClose(proxyWin, context);
         }
       });
   };

--- a/test/tests/error.js
+++ b/test/tests/error.js
@@ -290,7 +290,7 @@ describe("zoid error cases", () => {
 
         return runOnClick(() => {
           return instance.render("body", zoid.CONTEXT.POPUP);
-        }).catch(expect("catch"));
+        }).catch(avoid("catch"));
       },
       { timeout: 5000 }
     );


### PR DESCRIPTION
## Description

- Placed the popup check at the top to prevent any additional logic being run in the popup case.

- Adding Detected popup close error to the conditions that no longer reject the promise, but resolve the initial promise. Right now, we're getting this error in legitimate use cases such as when the user closes the popup mid-render. We're still closing and destroying the zoid component in this case, but we're avoiding an additional error from being thrown.

- Additional iframe checks are still in place