### PR TITLE
fix: reduce frequency of iframe removed error

### DIFF
--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -317,6 +317,7 @@ export function parentComponent<P, X, C>({
   let childComponent: ?ChildExportsType<P>;
   let currentChildDomain: ?string;
   let currentContainer: HTMLElement | void;
+  let isRenderFinished: boolean = false;
 
   const onErrorOverride: ?OnError = overrides.onError;
   let getProxyContainerOverride: ?GetProxyContainer =
@@ -862,11 +863,23 @@ export function parentComponent<P, X, C>({
       })
       .then((isClosed) => {
         if (!cancelled) {
-          if (isClosed) {
-            return close(new Error(`Detected ${context} close`));
-          } else {
-            return watchForClose(proxyWin, context);
+          if (context === CONTEXT.POPUP && isClosed) {
+            return close(new Error(COMPONENT_ERROR.POPUP_CLOSE));
           }
+
+          const isCurrentContainerClosed: boolean = Boolean(
+            currentContainer && isElementClosed(currentContainer)
+          );
+
+          if (
+            context === CONTEXT.IFRAME &&
+            isClosed &&
+            (isCurrentContainerClosed || isRenderFinished)
+          ) {
+            return close(new Error(COMPONENT_ERROR.IFRAME_CLOSE));
+          }
+
+          return watchForClose(proxyWin, context);
         }
       });
   };
@@ -1618,6 +1631,7 @@ export function parentComponent<P, X, C>({
       });
 
       const onRenderedPromise = initPromise.then(() => {
+        isRenderFinished = true;
         return event.trigger(EVENT.RENDERED);
       });
 


### PR DESCRIPTION
### Description

We're seeing rare cases when we see `Detected iframe close` before second render has a chance to finish in slow browsers with poor connection. With this change, we're adding an additional check before we decide to throw the error. 

Here is the example:
https://github.com/krakenjs/zoid/blob/main/src/parent/parent.js#L866