### PR TITLE
chore: more ci fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         # sets up the .npmrc file to publish to npm
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "12.13"
           registry-url: "https://registry.npmjs.org"
 
       - name: 📥 Download deps

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 // eslint-disable-next-line no-process-env
 if (process.env.ZOID_FRAME_ONLY) {
     // $FlowFixMe
-    module.exports = require('./dist/zoid.frame');
+    module.exports = require('./dist/zoid.frame'); // eslint-disable-line import/extensions,eslint-comments/no-unused-disable
     module.exports.default = module.exports;
 } else {
     // $FlowFixMe


### PR DESCRIPTION
* used `node v12.13` in `publish` gha due to compatibility issue with `npm v3`, which is pinned by `grumbler-scripts`.
* added `eslint disable` to `index.js` due to an issue where `eslint` interprets `.frame` as a file extension after dist has been deleted.