### PR TITLE
fix(venmo): window name

### DIFF
--- a/src/child/child.js
+++ b/src/child/child.js
@@ -35,6 +35,7 @@ import { normalizeChildProps } from "./props";
 export type ChildExportsType<P> = {|
   updateProps: CrossDomainFunctionType<[PropsType<P>], void>,
   close: CrossDomainFunctionType<[], void>,
+  name: string,
 |};
 
 export type ChildHelpers<P, X> = {|
@@ -302,8 +303,9 @@ export function childComponent<P, X, C>(
 
   const init = () => {
     return ZalgoPromise.try(() => {
+      let updatedChildName;
       if (isSameDomain(parentComponentWindow)) {
-        updateChildWindowNameWithRef({
+        updatedChildName = updateChildWindowNameWithRef({
           componentName: options.name,
           parentComponentWindow,
         });
@@ -317,7 +319,11 @@ export function childComponent<P, X, C>(
       markWindowKnown(parentComponentWindow);
       watchForClose();
 
-      return parentInit({ updateProps, close: destroy });
+      return parentInit({
+        name: updatedChildName,
+        updateProps,
+        close: destroy,
+      });
     })
       .then(() => {
         return watchForResize();

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -303,12 +303,13 @@ export function childComponent<P, X, C>(
 
   const init = () => {
     return ZalgoPromise.try(() => {
-      let updatedChildName;
+      let updatedChildName = "";
       if (isSameDomain(parentComponentWindow)) {
-        updatedChildName = updateChildWindowNameWithRef({
-          componentName: options.name,
-          parentComponentWindow,
-        });
+        updatedChildName =
+          updateChildWindowNameWithRef({
+            componentName: options.name,
+            parentComponentWindow,
+          }) || "";
       }
 
       getGlobal(window).exports = options.exports({

--- a/src/lib/window.js
+++ b/src/lib/window.js
@@ -185,7 +185,7 @@ type UpdateChildWindowNameWithRefOptions = {|
 export function updateChildWindowNameWithRef({
   componentName,
   parentComponentWindow,
-}: UpdateChildWindowNameWithRefOptions) {
+}: UpdateChildWindowNameWithRefOptions): string {
   const { serializedInitialPayload } = parseWindowName(window.name);
 
   const { data, sender, reference, metaData } = crossDomainDeserialize({
@@ -221,5 +221,7 @@ export function updateChildWindowNameWithRef({
       name: componentName,
       serializedPayload,
     });
+
+    return window.name;
   }
 }

--- a/src/lib/window.js
+++ b/src/lib/window.js
@@ -185,7 +185,7 @@ type UpdateChildWindowNameWithRefOptions = {|
 export function updateChildWindowNameWithRef({
   componentName,
   parentComponentWindow,
-}: UpdateChildWindowNameWithRefOptions): string {
+}: UpdateChildWindowNameWithRefOptions): ?string {
   const { serializedInitialPayload } = parseWindowName(window.name);
 
   const { data, sender, reference, metaData } = crossDomainDeserialize({
@@ -217,11 +217,12 @@ export function updateChildWindowNameWithRef({
       basic: true,
     });
 
-    window.name = buildChildWindowName({
+    const childWindowName = buildChildWindowName({
       name: componentName,
       serializedPayload,
     });
 
-    return window.name;
+    window.name = childWindowName;
+    return childWindowName;
   }
 }

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -626,8 +626,20 @@ export function parentComponent<P, X, C>({
   };
 
   const focus = (): ZalgoPromise<void> => {
-    return ZalgoPromise.try(() => {
+    return ZalgoPromise.try(async () => {
       if (currentProxyWin) {
+        const winType = await currentProxyWin.getType();
+        const winName = await currentProxyWin.getName();
+
+        if (winType === "popup") {
+          if (winName) {
+            return ZalgoPromise.all([
+              event.trigger(EVENT.FOCUS),
+              window.open("", winName),
+            ]).then(noop);
+          }
+        }
+
         return ZalgoPromise.all([
           event.trigger(EVENT.FOCUS),
           currentProxyWin.focus(),
@@ -712,6 +724,7 @@ export function parentComponent<P, X, C>({
     return ZalgoPromise.try(() => {
       currentChildDomain = childDomain;
       childComponent = childExports;
+      currentProxyWin.setName(childExports?.name);
       resolveInitPromise();
       clean.register(() => childExports.close.fireAndForget().catch(noop));
     });

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -626,20 +626,8 @@ export function parentComponent<P, X, C>({
   };
 
   const focus = (): ZalgoPromise<void> => {
-    return ZalgoPromise.try(async () => {
+    return ZalgoPromise.try(() => {
       if (currentProxyWin) {
-        const winType = await currentProxyWin.getType();
-        const winName = await currentProxyWin.getName();
-
-        if (winType === "popup") {
-          if (winName) {
-            return ZalgoPromise.all([
-              event.trigger(EVENT.FOCUS),
-              window.open("", winName),
-            ]).then(noop);
-          }
-        }
-
         return ZalgoPromise.all([
           event.trigger(EVENT.FOCUS),
           currentProxyWin.focus(),
@@ -724,7 +712,7 @@ export function parentComponent<P, X, C>({
     return ZalgoPromise.try(() => {
       currentChildDomain = childDomain;
       childComponent = childExports;
-      currentProxyWin.setName(childExports?.name);
+      currentProxyWin?.setName(childExports?.name);
       resolveInitPromise();
       clean.register(() => childExports.close.fireAndForget().catch(noop));
     });


### PR DESCRIPTION
## Issue
Window name wasn't being updated if redirecting in popup. This caused blank windows to open when sending focus event to popup as window name did not match.

## Solution
Send updated name to parent initialization to update the proxy window name.