### PR TITLE
fix(initChild): setName is applied in popup context

### DIFF
--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -714,14 +714,17 @@ export function parentComponent<P, X, C>({
       currentChildDomain = childDomain;
       childComponent = childExports;
 
-      currentProxyWin?.isPopup().then((isPopup) => {
-        if (childExports?.name !== "" && isPopup) {
-          currentProxyWin?.setName(childExports?.name);
-        }
-
-        resolveInitPromise();
-        clean.register(() => childExports.close.fireAndForget().catch(noop));
-      });
+      currentProxyWin
+        ?.isPopup()
+        .then((isPopup) => {
+          if (childExports?.name !== "" && isPopup) {
+            currentProxyWin?.setName(childExports?.name);
+          }
+        })
+        .finally(() => {
+          resolveInitPromise();
+          clean.register(() => childExports.close.fireAndForget().catch(noop));
+        });
     });
   };
 

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -710,17 +710,18 @@ export function parentComponent<P, X, C>({
     childDomain: string,
     childExports: ChildExportsType<P>
   ): ZalgoPromise<void> => {
-    return ZalgoPromise.try(async () => {
+    return ZalgoPromise.try(() => {
       currentChildDomain = childDomain;
       childComponent = childExports;
 
-      const context = await currentProxyWin.getType();
-      if (childExports?.name !== "" && context === "popup") {
-        currentProxyWin?.setName(childExports?.name);
-      }
+      currentProxyWin?.isPopup().then((isPopup) => {
+        if (childExports?.name !== "" && isPopup) {
+          currentProxyWin?.setName(childExports?.name);
+        }
 
-      resolveInitPromise();
-      clean.register(() => childExports.close.fireAndForget().catch(noop));
+        resolveInitPromise();
+        clean.register(() => childExports.close.fireAndForget().catch(noop));
+      });
     });
   };
 

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -713,7 +713,11 @@ export function parentComponent<P, X, C>({
     return ZalgoPromise.try(() => {
       currentChildDomain = childDomain;
       childComponent = childExports;
-      currentProxyWin?.setName(childExports?.name);
+
+      if (childExports?.name !== "") {
+        currentProxyWin?.setName(childExports?.name);
+      }
+
       resolveInitPromise();
       clean.register(() => childExports.close.fireAndForget().catch(noop));
     });

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -710,11 +710,12 @@ export function parentComponent<P, X, C>({
     childDomain: string,
     childExports: ChildExportsType<P>
   ): ZalgoPromise<void> => {
-    return ZalgoPromise.try(() => {
+    return ZalgoPromise.try(async () => {
       currentChildDomain = childDomain;
       childComponent = childExports;
 
-      if (childExports?.name !== "") {
+      const context = await currentProxyWin.getType();
+      if (childExports?.name !== "" && context === "popup") {
         currentProxyWin?.setName(childExports?.name);
       }
 


### PR DESCRIPTION
## Description
Ensure `setName` is called with `name` present and in the context of a popup.