### PR TITLE
Remove listener for deprecated DOMNodeInserted event

### DIFF
--- a/src/drivers/script.js
+++ b/src/drivers/script.js
@@ -45,12 +45,6 @@ export let script : ComponentDriverType<*, Document> = {
         }
 
         scan();
-        document.addEventListener('DOMContentLoaded', scan);
         window.addEventListener('load', scan);
-
-        document.addEventListener('DOMNodeInserted', event => {
-            // $FlowFixMe
-            render(event.target);
-        });
     }
 };


### PR DESCRIPTION
`DOMNodeInserted` and a handful of other events will become unsupported in chrome [later this year](https://developer.chrome.com/blog/mutation-events-deprecation/).