### PR TITLE
fix: resolve the promise when component is closed/destroyed

### DIFF
--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -753,7 +753,8 @@ export function parentComponent<P, X, C>({
         const error = err || new Error(COMPONENT_ERROR.COMPONENT_DESTROYED);
         if (
           (currentContainer && isElementClosed(currentContainer)) ||
-          error.message === COMPONENT_ERROR.NAVIGATED_AWAY
+          // $FlowFixMe
+          Object.values(COMPONENT_ERROR).includes(error.message)
         ) {
           initPromise.resolve();
         } else {


### PR DESCRIPTION
**Problem:** Due to asynchronous render, whenever a component is canceled before it has finished rendering, zoid throws the Component closed error.
**Fixes:** https://github.com/krakenjs/zoid/issues/334
<img width="968" alt="Screenshot 2024-05-15 at 5 27 54 PM" src="https://github.com/krakenjs/zoid/assets/24843989/9b383097-7636-4df0-982b-cd0d0d64575f">

**Solution:**
We want to reject the promise only if an error occurs that's not one of the component unmounted errors. 