### PR TITLE
feat: add getExtensions method to extend zoid component instance

### DIFF
--- a/src/child/child.js
+++ b/src/child/child.js
@@ -96,8 +96,8 @@ export type ChildComponent<P, X> = {|
   init: () => ZalgoPromise<void>,
 |};
 
-export function childComponent<P, X, C>(
-  options: NormalizedComponentOptionsType<P, X, C>
+export function childComponent<P, X, C, ExtType>(
+  options: NormalizedComponentOptionsType<P, X, C, ExtType>
 ): ChildComponent<P, X> {
   const { tag, propsDef, autoResize, allowedParentDomains } = options;
 

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -29,6 +29,7 @@ import {
 
 import { childComponent, type ChildComponent } from "../child";
 import {
+  type ParentComponent,
   type RenderOptionsType,
   type ParentHelpers,
   parentComponent,
@@ -109,7 +110,7 @@ export type ExportsDefinition<X> =
 export type ComponentOptionsType<P, X, C, ExtType> = {|
   tag: string,
 
-  getExtensions?: (parentProps: PropsType<P>) => ExtType,
+  getExtensions?: (parent: ParentComponent<P, X>) => ExtType,
   url: string | (({| props: PropsType<P> |}) => string),
   domain?: DomainMatcher,
   bridgeUrl?: string,
@@ -160,7 +161,7 @@ export type NormalizedComponentOptionsType<P, X, C, ExtType> = {|
   tag: string,
   name: string,
 
-  getExtensions: (parentProps: PropsType<P>) => ExtType,
+  getExtensions: (parent: ParentComponent<P, X>) => ExtType,
   url: string | (({| props: PropsType<P> |}) => string),
   domain: ?DomainMatcher,
   bridgeUrl: ?string,
@@ -243,8 +244,8 @@ const getDefaultDimensions = (): CssDimensionsType => {
   return {};
 };
 
-function getDefaultGetExtensions<P, ExtType>(): (
-  parentProps: PropsType<P>
+function getDefaultGetExtensions<P, X, ExtType>(): (
+  parent: ParentComponent<P, X>
 ) => ExtType {
   return function getExtensions(): ExtType {
     // $FlowFixMe
@@ -262,7 +263,7 @@ function normalizeOptions<P, X, C, ExtType>(
     domain,
     bridgeUrl,
     props = {},
-    getExtensions = getDefaultGetExtensions<P, ExtType>(),
+    getExtensions = getDefaultGetExtensions<P, X, ExtType>(),
     dimensions = getDefaultDimensions(),
     autoResize = getDefaultAutoResize(),
     allowedParentDomains = WILDCARD,
@@ -615,7 +616,7 @@ export function component<P, X, C, ExtType>(
     };
 
     instance = {
-      ...getExtensions(parent.getProps()),
+      ...getExtensions(parent),
       ...parent.getExports(),
       ...parent.getHelpers(),
       ...getChildren(),

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -106,9 +106,10 @@ export type ExportsDefinition<X> =
   | ExportsConfigDefinition
   | ExportsMapperDefinition<X>;
 
-export type ComponentOptionsType<P, X, C> = {|
+export type ComponentOptionsType<P, X, C, ExtType> = {|
   tag: string,
 
+  getExtensions?: (parentProps: X) => ExtType,
   url: string | (({| props: PropsType<P> |}) => string),
   domain?: DomainMatcher,
   bridgeUrl?: string,
@@ -155,10 +156,11 @@ type AutoResizeType = {|
   element?: string,
 |};
 
-export type NormalizedComponentOptionsType<P, X, C> = {|
+export type NormalizedComponentOptionsType<P, X, C, ExtType> = {|
   tag: string,
   name: string,
 
+  getExtensions: (parentProps: X) => ExtType,
   url: string | (({| props: PropsType<P> |}) => string),
   domain: ?DomainMatcher,
   bridgeUrl: ?string,
@@ -192,12 +194,13 @@ export type NormalizedComponentOptionsType<P, X, C> = {|
   exports: ExportsMapperDefinition<X>,
 |};
 
-export type ZoidComponentInstance<P, X = void, C = void> = {|
+export type ZoidComponentInstance<P, X = void, C = void, ExtType = void> = {|
   ...ParentHelpers<P>,
   ...X,
   ...C,
+  ...ExtType,
   isEligible: () => boolean,
-  clone: () => ZoidComponentInstance<P, X, C>,
+  clone: () => ZoidComponentInstance<P, X, C, ExtType>,
   render: (
     container?: ContainerReferenceType,
     context?: $Values<typeof CONTEXT>
@@ -210,14 +213,14 @@ export type ZoidComponentInstance<P, X = void, C = void> = {|
 |};
 
 // eslint-disable-next-line flowtype/require-exact-type
-export type ZoidComponent<P, X = void, C = void> = {
-  (props?: PropsInputType<P> | void): ZoidComponentInstance<P, X, C>,
+export type ZoidComponent<P, X = void, C = void, ExtType = void> = {
+  (props?: PropsInputType<P> | void): ZoidComponentInstance<P, X, C, ExtType>,
   // eslint-disable-next-line no-undef
   driver: <T>(string, mixed) => T,
   isChild: () => boolean,
   xprops?: PropsType<P>,
   canRenderTo: (CrossDomainWindowType) => ZalgoPromise<boolean>,
-  instances: $ReadOnlyArray<ZoidComponentInstance<P, X, C>>,
+  instances: $ReadOnlyArray<ZoidComponentInstance<P, X, C, ExtType>>,
 };
 
 const getDefaultAttributes = (): AttributesType => {
@@ -240,15 +243,24 @@ const getDefaultDimensions = (): CssDimensionsType => {
   return {};
 };
 
-function normalizeOptions<P, X, C>(
-  options: ComponentOptionsType<P, X, C>
-): NormalizedComponentOptionsType<P, X, C> {
+function getDefaultGetExtensions<X, ExtType>(): (parentProps: X) => ExtType {
+  return function getExtensions(): ExtType {
+    // $FlowFixMe
+    const ext: ExtType = {};
+    return ext;
+  };
+}
+
+function normalizeOptions<P, X, C, ExtType>(
+  options: ComponentOptionsType<P, X, C, ExtType>
+): NormalizedComponentOptionsType<P, X, C, ExtType> {
   const {
     tag,
     url,
     domain,
     bridgeUrl,
     props = {},
+    getExtensions = getDefaultGetExtensions<X, ExtType>(),
     dimensions = getDefaultDimensions(),
     autoResize = getDefaultAutoResize(),
     allowedParentDomains = WILDCARD,
@@ -329,31 +341,42 @@ function normalizeOptions<P, X, C>(
     eligible,
     children,
     exports: xports,
+    getExtensions,
   };
 }
 
 let cleanInstances = cleanup();
 const cleanZoid = cleanup();
 
-export type Component<P, X, C> = {|
-  init: (props?: PropsInputType<P> | void) => ZoidComponentInstance<P, X, C>,
-  instances: $ReadOnlyArray<ZoidComponentInstance<P, X, C>>,
+export type Component<P, X, C, ExtType> = {|
+  init: (
+    props?: PropsInputType<P> | void
+  ) => ZoidComponentInstance<P, X, C, ExtType>,
+  instances: $ReadOnlyArray<ZoidComponentInstance<P, X, C, ExtType>>,
   driver: (string, mixed) => mixed,
   isChild: () => boolean,
   canRenderTo: (CrossDomainWindowType) => ZalgoPromise<boolean>,
   registerChild: () => ?ChildComponent<P, X>,
 |};
 
-export function component<P, X, C>(
-  opts: ComponentOptionsType<P, X, C>
-): Component<P, X, C> {
+export function component<P, X, C, ExtType>(
+  opts: ComponentOptionsType<P, X, C, ExtType>
+): Component<P, X, C, ExtType> {
   if (__DEBUG__) {
     validateOptions(opts);
   }
 
   const options = normalizeOptions(opts);
 
-  const { name, tag, defaultContext, propsDef, eligible, children } = options;
+  const {
+    name,
+    tag,
+    defaultContext,
+    propsDef,
+    eligible,
+    children,
+    getExtensions,
+  } = options;
 
   const global = getGlobal(window);
   const driverCache = {};
@@ -471,7 +494,7 @@ export function component<P, X, C>(
 
   const init = (
     inputProps?: PropsInputType<P> | void
-  ): ZoidComponentInstance<P, X, C> => {
+  ): ZoidComponentInstance<P, X, C, ExtType> => {
     // eslint-disable-next-line prefer-const
     let instance;
 
@@ -593,6 +616,7 @@ export function component<P, X, C>(
       ...parent.getExports(),
       ...parent.getHelpers(),
       ...getChildren(),
+      ...getExtensions(parent.getExports()),
       isEligible,
       clone,
       render: (container, context) => render(window, container, context),
@@ -663,15 +687,15 @@ export type ComponentDriverType<P, L, D, X, C> = {|
 export type ZoidProps<P> = PropsType<P>;
 
 // eslint-disable-next-line no-undef
-export type CreateZoidComponent = <P, X, C>(
+export type CreateZoidComponent = <P, X, C, ExtType>(
   // eslint-disable-next-line no-undef
-  options: ComponentOptionsType<P, X, C>
+  options: ComponentOptionsType<P, X, C, ExtType>
   // eslint-disable-next-line no-undef
-) => ZoidComponent<P, X, C>;
+) => ZoidComponent<P, X, C, ExtType>;
 
-export const create: CreateZoidComponent = <P, X, C>(
-  options: ComponentOptionsType<P, X, C>
-): ZoidComponent<P, X, C> => {
+export const create: CreateZoidComponent = <P, X, C, ExtType>(
+  options: ComponentOptionsType<P, X, C, ExtType>
+): ZoidComponent<P, X, C, ExtType> => {
   setupPostRobot();
 
   const comp = component(options);

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -109,7 +109,7 @@ export type ExportsDefinition<X> =
 export type ComponentOptionsType<P, X, C, ExtType> = {|
   tag: string,
 
-  getExtensions?: (parentProps: X) => ExtType,
+  getExtensions?: (parentProps: PropsType<P>) => ExtType,
   url: string | (({| props: PropsType<P> |}) => string),
   domain?: DomainMatcher,
   bridgeUrl?: string,
@@ -160,7 +160,7 @@ export type NormalizedComponentOptionsType<P, X, C, ExtType> = {|
   tag: string,
   name: string,
 
-  getExtensions: (parentProps: X) => ExtType,
+  getExtensions: (parentProps: PropsType<P>) => ExtType,
   url: string | (({| props: PropsType<P> |}) => string),
   domain: ?DomainMatcher,
   bridgeUrl: ?string,
@@ -195,10 +195,10 @@ export type NormalizedComponentOptionsType<P, X, C, ExtType> = {|
 |};
 
 export type ZoidComponentInstance<P, X = void, C = void, ExtType = void> = {|
+  ...ExtType,
   ...ParentHelpers<P>,
   ...X,
   ...C,
-  ...ExtType,
   isEligible: () => boolean,
   clone: () => ZoidComponentInstance<P, X, C, ExtType>,
   render: (
@@ -243,7 +243,9 @@ const getDefaultDimensions = (): CssDimensionsType => {
   return {};
 };
 
-function getDefaultGetExtensions<X, ExtType>(): (parentProps: X) => ExtType {
+function getDefaultGetExtensions<P, ExtType>(): (
+  parentProps: PropsType<P>
+) => ExtType {
   return function getExtensions(): ExtType {
     // $FlowFixMe
     const ext: ExtType = {};
@@ -260,7 +262,7 @@ function normalizeOptions<P, X, C, ExtType>(
     domain,
     bridgeUrl,
     props = {},
-    getExtensions = getDefaultGetExtensions<X, ExtType>(),
+    getExtensions = getDefaultGetExtensions<P, ExtType>(),
     dimensions = getDefaultDimensions(),
     autoResize = getDefaultAutoResize(),
     allowedParentDomains = WILDCARD,
@@ -613,10 +615,10 @@ export function component<P, X, C, ExtType>(
     };
 
     instance = {
+      ...getExtensions(parent.getProps()),
       ...parent.getExports(),
       ...parent.getHelpers(),
       ...getChildren(),
-      ...getExtensions(parent.getExports()),
       isEligible,
       clone,
       render: (container, context) => render(window, container, context),

--- a/src/component/validate.js
+++ b/src/component/validate.js
@@ -6,8 +6,8 @@ import { CONTEXT, PROP_TYPE } from "../constants";
 
 import type { ComponentOptionsType } from "./index";
 
-function validatepropsDefinitions<P, X, C>(
-  options: ComponentOptionsType<P, X, C>
+function validatepropsDefinitions<P, X, C, ExtType>(
+  options: ComponentOptionsType<P, X, C, ExtType>
 ) {
   if (options.props && !(typeof options.props === "object")) {
     throw new Error(`Expected options.props to be an object`);
@@ -49,8 +49,8 @@ function validatepropsDefinitions<P, X, C>(
 }
 
 // eslint-disable-next-line complexity
-export function validateOptions<P, X, C>(
-  options: ?ComponentOptionsType<P, X, C>
+export function validateOptions<P, X, C, ExtType>(
+  options: ?ComponentOptionsType<P, X, C, ExtType>
 ) {
   // eslint-ignore-line
 

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -271,19 +271,19 @@ const getDefaultOverrides = <P>(): ParentDelegateOverrides<P> => {
   return {};
 };
 
-type ParentOptions<P, X, C> = {|
+type ParentOptions<P, X, C, ExtType> = {|
   uid: string,
-  options: NormalizedComponentOptionsType<P, X, C>,
+  options: NormalizedComponentOptionsType<P, X, C, ExtType>,
   overrides?: ParentDelegateOverrides<P>,
   parentWin?: CrossDomainWindowType,
 |};
 
-export function parentComponent<P, X, C>({
+export function parentComponent<P, X, C, ExtType>({
   uid,
   options,
   overrides = getDefaultOverrides(),
   parentWin = window,
-}: ParentOptions<P, X, C>): ParentComponent<P, X> {
+}: ParentOptions<P, X, C, ExtType>): ParentComponent<P, X> {
   const {
     propsDef,
     containerTemplate,

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -254,7 +254,7 @@ type RenderOptions = {|
   rerender: Rerender,
 |};
 
-type ParentComponent<P, X> = {|
+export type ParentComponent<P, X> = {|
   init: () => void,
   render: (RenderOptions) => ZalgoPromise<void>,
   getProps: () => PropsType<P>,

--- a/test/tests/extensions.jsx
+++ b/test/tests/extensions.jsx
@@ -93,10 +93,10 @@ describe("zoid getExtensions cases", () => {
           tag: "test-render-with-extended-method-invokes-callbacks",
           url: () => "mock://www.child.com/base/test/windows/child/index.htm",
           domain: "mock://www.child.com",
-          getExtensions: (props) => {
+          getExtensions: (parent) => {
             return {
               invokeCalculatePrice: () => {
-                return props.calculatePrice();
+                return parent.getProps().calculatePrice();
               },
             };
           },

--- a/test/tests/extensions.jsx
+++ b/test/tests/extensions.jsx
@@ -1,0 +1,129 @@
+/* @flow */
+/** @jsx node */
+
+import { wrapPromise } from "@krakenjs/belter/src";
+import { getParent } from "@krakenjs/cross-domain-utils/src";
+
+import { onWindowOpen, getBody } from "../common";
+import { zoid } from "../zoid";
+
+describe("zoid getExtensions cases", () => {
+  it("should render a component with additional properties to the component", () => {
+    return wrapPromise(({ expect }) => {
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-render-with-extended-properties",
+          url: () => "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+          getExtensions: () => {
+            return {
+              testAttribute: "123",
+              testMethod: () => "result_of_test_method",
+            };
+          },
+        });
+      };
+
+      onWindowOpen().then(
+        expect("onWindowOpen", ({ win }) => {
+          if (getParent(win) !== window) {
+            throw new Error(`Expected window parent to be current window`);
+          }
+        })
+      );
+
+      const component = window.__component__();
+      const instance = component({
+        onRendered: expect("onRendered"),
+      });
+
+      if (instance.testAttribute !== "123") {
+        throw new Error(
+          `Expected test attribute to be "123", but got ${instance.testAttribute}`
+        );
+      }
+      if (instance.testMethod() !== "result_of_test_method") {
+        throw new Error(
+          `Expected test attribute to be "result_of_test_method", but got ${instance.testMethod()}`
+        );
+      }
+
+      return instance.render(getBody());
+    });
+  });
+
+  it("should not be able to ovverride default properties of component using getExtensions", () => {
+    return wrapPromise(({ expect }) => {
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-extended-properties-cannot-override-defaults",
+          url: () => "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+          getExtensions: () => {
+            return {
+              render: () => {
+                throw new Error("The render method should have been ovveriden");
+              },
+            };
+          },
+        });
+      };
+
+      onWindowOpen().then(
+        expect("onWindowOpen", ({ win }) => {
+          if (getParent(win) !== window) {
+            throw new Error(`Expected window parent to be current window`);
+          }
+        })
+      );
+
+      const component = window.__component__();
+      const instance = component({
+        onRendered: expect("onRendered"),
+      });
+
+      return instance.render(getBody());
+    });
+  });
+
+  it("should be able to interact with method supplied to the component during instantiation", () => {
+    return wrapPromise(({ expect }) => {
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-render-with-extended-method-invokes-callbacks",
+          url: () => "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+          getExtensions: (props) => {
+            return {
+              invokeCalculatePrice: () => {
+                return props.calculatePrice();
+              },
+            };
+          },
+        });
+      };
+
+      onWindowOpen().then(
+        expect("onWindowOpen", ({ win }) => {
+          if (getParent(win) !== window) {
+            throw new Error(`Expected window parent to be current window`);
+          }
+        })
+      );
+
+      const component = window.__component__();
+      const instance = component({
+        onRendered: expect("onRendered"),
+        calculatePrice: () => 1034.56,
+      });
+
+      if (instance.invokeCalculatePrice() !== 1034.56) {
+        throw new Error(
+          `Expected test attribute to be "result_of_test_method", but got ${instance.testMethod()}`
+        );
+      }
+
+      return instance.render(getBody());
+    });
+  });
+});

--- a/test/tests/extensions.jsx
+++ b/test/tests/extensions.jsx
@@ -119,7 +119,53 @@ describe("zoid getExtensions cases", () => {
 
       if (instance.invokeCalculatePrice() !== 1034.56) {
         throw new Error(
-          `Expected test attribute to be "result_of_test_method", but got ${instance.testMethod()}`
+          `Expected test attribute to be "1034.56", but got ${instance.invokeCalculatePrice()}`
+        );
+      }
+
+      return instance.render(getBody());
+    });
+  });
+
+  it("should be able to interact with updated methods supplied to the component during instantiation", () => {
+    return wrapPromise(({ expect }) => {
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-render-with-updated-extended-method-invokes-callbacks",
+          url: () => "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+          getExtensions: (parent) => {
+            return {
+              invokeCalculatePrice: () => {
+                return parent.getProps().calculatePrice();
+              },
+            };
+          },
+        });
+      };
+
+      onWindowOpen().then(
+        expect("onWindowOpen", ({ win }) => {
+          if (getParent(win) !== window) {
+            throw new Error(`Expected window parent to be current window`);
+          }
+        })
+      );
+
+      const component = window.__component__();
+
+      const instance = component({
+        onRendered: expect("onRendered"),
+        calculatePrice: () => 1034.56,
+      });
+
+      instance.updateProps({
+        calculatePrice: () => 50.56,
+      });
+
+      if (instance.invokeCalculatePrice() !== 50.56) {
+        throw new Error(
+          `Expected test attribute to be "50.56", but got ${instance.invokeCalculatePrice()}`
         );
       }
 

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -20,3 +20,4 @@ import "./remove";
 import "./rerender";
 import "./method";
 import "./children";
+import "./extensions";


### PR DESCRIPTION
* We have a use case where its necessary to add support for additional methods on the Zoid component instance. 
* To support this use case  `getExtensions` callback is being added to create method.
* Zoid would call this method to add the additional properties returned by this callback on the component instances. 
* This method will accept the parent props as an argument so that the extended methods could interact with props passed during initialization. 
* The implementation will ensure that `getExtensions` cannot override any of the existing methods in Zoid like render, clone etc. 

Sample usage

```javascript
const MyComponent = zoid.create({
    tag: "custom-buttons",
    getExtensions: (parent) => {
     // methods defined in parent props, like `onCancel` will be available in 
     // props returned by parent.getProps();
      return {
        hasReturned: () => true,
        resume: () => {
          console.log("Resuming ....");
        },
      };
    }
});

const component = MyComponent({ 
     onCancel: function() { ... }
})
```
Now the `component` instance will contain the additional methods along with standard methods. 
e.g.
```javascript
component.hasReturned(); // will return true
component.resume(); // will log Resuming .... on console. 
```



