### PR TITLE
chore: remove deprecated unload event listener

### DIFF
--- a/src/child/child.js
+++ b/src/child/child.js
@@ -222,14 +222,9 @@ export function childComponent<P, X, C, ExtType>(
   };
 
   const watchForClose = () => {
-    window.addEventListener("beforeunload", () => {
+    window.addEventListener("pagehide", () => {
       checkClose.fireAndForget();
     });
-
-    // unload event is deprecated
-    // window.addEventListener("unload", () => {
-    //   checkClose.fireAndForget();
-    // });
 
     onCloseWindow(parentComponentWindow, () => {
       destroy();

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -226,9 +226,10 @@ export function childComponent<P, X, C, ExtType>(
       checkClose.fireAndForget();
     });
 
-    window.addEventListener("unload", () => {
-      checkClose.fireAndForget();
-    });
+    // unload event is deprecated
+    // window.addEventListener("unload", () => {
+    //   checkClose.fireAndForget();
+    // });
 
     onCloseWindow(parentComponentWindow, () => {
       destroy();


### PR DESCRIPTION
- The unload event listener has been commented out to avoid using the deprecated event.

- The beforeunload event listener is already in place and will handle the necessary actions before the window is unloaded.