### PR TITLE
[Feature] Re-render PayPal Button on `onCancel` and `onError`

### DIFF
--- a/src/component/component.js
+++ b/src/component/component.js
@@ -384,6 +384,173 @@ export function component<P, X, C, ExtType>(
   const global = getGlobal(window);
   const driverCache = {};
   const instances = [];
+  let latestRenderedRerender: ?() => ZalgoPromise<void>;
+  const latestRenderStorageKey = `__zoid_latest_render__${tag}`;
+  const latestRenderContainerAttr = `data-zoid-latest-container-${tag}`;
+  const escapeAttr = (value: string): string => {
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  };
+  const waitForSelector = (
+    selector: string,
+    timeout: number = 3000,
+    interval: number = 100
+  ): ZalgoPromise<string> => {
+    return new ZalgoPromise((resolve, reject) => {
+      const start = Date.now();
+
+      const check = () => {
+        try {
+          if (document.querySelector(selector)) {
+            resolve(selector);
+            return;
+          }
+        } catch (err) {
+          reject(err);
+          return;
+        }
+
+        if (Date.now() - start >= timeout) {
+          reject(
+            new Error(
+              `Timed out waiting for container selector to appear: ${selector}`
+            )
+          );
+          return;
+        }
+
+        setTimeout(check, interval);
+      };
+
+      check();
+    });
+  };
+
+  const readLatestRender = (): ?{|
+    container: string,
+    context: $Values<typeof CONTEXT>,
+  |} => {
+    try {
+      if (!window.sessionStorage) {
+        return;
+      }
+
+      const latestRender = window.sessionStorage.getItem(
+        latestRenderStorageKey
+      );
+      if (!latestRender) {
+        return;
+      }
+
+      const parsed = JSON.parse(latestRender);
+      const persistedContainers =
+        parsed && Array.isArray(parsed.containers)
+          ? parsed.containers.filter(
+              (candidate) => typeof candidate === "string"
+            )
+          : [];
+
+      let candidates = persistedContainers;
+
+      if (candidates.length === 0) {
+        if (parsed && typeof parsed.container === "string") {
+          candidates = [parsed.container];
+        } else {
+          candidates = [];
+        }
+      }
+
+      if (!parsed || candidates.length === 0) {
+        return;
+      }
+
+      if (
+        parsed.context !== CONTEXT.IFRAME &&
+        parsed.context !== CONTEXT.POPUP
+      ) {
+        return;
+      }
+
+      const container =
+        candidates.find((candidate) => {
+          try {
+            return Boolean(document.querySelector(candidate));
+          } catch (err) {
+            return false;
+          }
+        }) || candidates[0];
+
+      return {
+        container,
+        context: parsed.context,
+      };
+    } catch (err) {
+      // ignored
+    }
+  };
+
+  const writeLatestRender = (
+    container: ContainerReferenceType,
+    context: $Values<typeof CONTEXT>
+  ) => {
+    let persistedContainer: ?string;
+    const persistedContainers = [];
+
+    if (typeof container === "string") {
+      persistedContainer = container;
+      persistedContainers.push(container);
+    } else if (isElement(container)) {
+      const elementID = container.getAttribute("id");
+      if (elementID) {
+        persistedContainers.push(`[id="${escapeAttr(elementID)}"]`);
+      }
+
+      const elementName = container.getAttribute("name");
+      if (elementName) {
+        persistedContainers.push(`[name="${escapeAttr(elementName)}"]`);
+      }
+
+      const className = container.className;
+      if (typeof className === "string" && className.trim()) {
+        const firstClass = className.trim().split(/\s+/)[0];
+        if (firstClass) {
+          persistedContainers.push(`.${firstClass}`);
+        }
+      }
+
+      let marker = container.getAttribute(latestRenderContainerAttr);
+
+      if (!marker) {
+        marker = uniqueID();
+        container.setAttribute(latestRenderContainerAttr, marker);
+      }
+
+      persistedContainers.push(
+        `[${latestRenderContainerAttr}="${escapeAttr(marker)}"]`
+      );
+      persistedContainer = persistedContainers[0];
+    }
+
+    if (!persistedContainer) {
+      return;
+    }
+
+    try {
+      if (!window.sessionStorage) {
+        return;
+      }
+
+      window.sessionStorage.setItem(
+        latestRenderStorageKey,
+        JSON.stringify({
+          container: persistedContainer,
+          containers: persistedContainers,
+          context,
+        })
+      );
+    } catch (err) {
+      // ignored
+    }
+  };
 
   const isChild = (): boolean => {
     if (isChildComponentWindow(name)) {
@@ -521,6 +688,22 @@ export function component<P, X, C, ExtType>(
     const parent = parentComponent({
       uid,
       options,
+      getFallbackRerender: () => {
+        if (latestRenderedRerender) {
+          return latestRenderedRerender;
+        }
+
+        const latestRender = readLatestRender();
+        if (!latestRender) {
+          return;
+        }
+
+        return () => {
+          return waitForSelector(latestRender.container).then((selector) => {
+            return instance.render(selector, latestRender.context);
+          });
+        };
+      },
     });
 
     parent.init();
@@ -597,15 +780,20 @@ export function component<P, X, C, ExtType>(
             );
           }
 
+          const rerender = () => {
+            const newInstance = clone();
+            extend(instance, newInstance);
+            return newInstance.renderTo(target, container, context);
+          };
+
+          latestRenderedRerender = rerender;
+          writeLatestRender(container, finalContext);
+
           return parent.render({
             target,
             container,
             context: finalContext,
-            rerender: () => {
-              const newInstance = clone();
-              extend(instance, newInstance);
-              return newInstance.renderTo(target, container, context);
-            },
+            rerender,
           });
         })
         .catch((err) => {

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -209,6 +209,7 @@ type OpenPrerender = (
 type WatchForUnload = () => ZalgoPromise<void>;
 type GetInternalState = () => ZalgoPromise<InternalState>;
 type SetInternalState = (InternalState) => ZalgoPromise<InternalState>;
+type GetFallbackRerender = () => ?Rerender;
 
 type ParentDelegateOverrides<P> = {|
   props: PropsType<P>,
@@ -277,6 +278,7 @@ type ParentOptions<P, X, C, ExtType> = {|
   options: NormalizedComponentOptionsType<P, X, C, ExtType>,
   overrides?: ParentDelegateOverrides<P>,
   parentWin?: CrossDomainWindowType,
+  getFallbackRerender?: GetFallbackRerender,
 |};
 
 export function parentComponent<P, X, C, ExtType>({
@@ -284,6 +286,7 @@ export function parentComponent<P, X, C, ExtType>({
   options,
   overrides = getDefaultOverrides(),
   parentWin = window,
+  getFallbackRerender = () => null,
 }: ParentOptions<P, X, C, ExtType>): ParentComponent<P, X> {
   const {
     propsDef,
@@ -1285,7 +1288,9 @@ export function parentComponent<P, X, C, ExtType>({
       show,
       hide,
       rerender: () => {
-        const rerenderFn = currentRerender || lastRerender;
+        const fallbackRerender = getFallbackRerender();
+        const rerenderFn = currentRerender || lastRerender || fallbackRerender;
+
         if (!rerenderFn) {
           if (!hasBeenRendered) {
             throw new Error(

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -146,6 +146,7 @@ export type ParentHelpers<P> = {|
   event: EventEmitterType,
   show: () => ZalgoPromise<void>,
   hide: () => ZalgoPromise<void>,
+  rerender: () => ZalgoPromise<void>,
 |};
 
 function getDefaultProps<P>(): PropsType<P> {
@@ -317,6 +318,9 @@ export function parentComponent<P, X, C, ExtType>({
   let childComponent: ?ChildExportsType<P>;
   let currentChildDomain: ?string;
   let currentContainer: HTMLElement | void;
+  let currentRerender: ?Rerender = null;
+  let lastRerender: ?Rerender = null;
+  let hasBeenRendered: boolean = false;
   let isRenderFinished: boolean = false;
 
   const onErrorOverride: ?OnError = overrides.onError;
@@ -1280,6 +1284,20 @@ export function parentComponent<P, X, C, ExtType>({
       updateProps,
       show,
       hide,
+      rerender: () => {
+        const rerenderFn = currentRerender || lastRerender;
+        if (!rerenderFn) {
+          if (!hasBeenRendered) {
+            throw new Error(
+              "Rerender not available - component must be rendered first."
+            );
+          }
+          throw new Error(
+            "Rerender callback lost after render - component may be destroyed or re-initialized."
+          );
+        }
+        return rerenderFn();
+      },
     };
   };
 
@@ -1509,6 +1527,9 @@ export function parentComponent<P, X, C, ExtType>({
     rerender,
   }: RenderOptions): ZalgoPromise<void> => {
     return ZalgoPromise.try(() => {
+      currentRerender = rerender;
+      lastRerender = rerender;
+      hasBeenRendered = true;
       const initialChildDomain = getInitialChildDomain();
       const childDomainMatch = getDomainMatcher();
 


### PR DESCRIPTION
### Description

Updates Zoid behavior to support re-rendering a component after an app switch resume flow completes through cancel or error.

**Problem:** In app switch resume flows, the PayPal button can disappear after cancel because the existing Zoid instance has already been used for the resume/pixel flow, and merchant retry logic needs a clean render path once the resume flow exits.

**Solution:** Allow the parent integration to close the resume pixel flow and render the button again into the merchant container after onCancel/onError completes.

**Impact:** PayPal Checkout can restore the button after app switch cancel/error flows, so buyers can retry payment without requiring manual merchant intervention or a stale component state.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

  1. DTRIMAC-2082
  2. DTPPCPSDK-4375

### Reproduction Steps (if applicable)

Same reproduction flow as the paired paypal-checkout-components PR: https://github.com/paypal/paypal-checkout-components/pull/2592.

### Dependent Changes (if applicable)

These changes are to be tested with the paired paypal-checkout-components PR: https://github.com/paypal/paypal-checkout-components/pull/2592 and SCNW PR: #1183
