### PR TITLE
feat: add bfcacheEnabled component option and gate parent guards in zoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [10.6.0-alpha.1](https://github.com/krakenjs/zoid/compare/v10.5.1...v10.6.0-alpha.1) (2026-04-01)
+
+
+### Features
+
+* add bfcacheEnabled component option and gate parent guards in zoid ([846fcba](https://github.com/krakenjs/zoid/commit/846fcba81ce57aaf05c96a75753c194c12890344))
+* alpha version ([a79de90](https://github.com/krakenjs/zoid/commit/a79de90df4b4532cb12e161075570813cab190ec))
+* changes ([70a5c78](https://github.com/krakenjs/zoid/commit/70a5c7818e49dae80b031fcbc810f008307ca2d3))
+
 ### [10.5.1](https://github.com/krakenjs/zoid/compare/v10.5.0...v10.5.1) (2026-03-23)
 
 ## [10.5.0](https://github.com/krakenjs/zoid/compare/v10.4.0...v10.5.0) (2026-01-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [10.6.0-alpha.1](https://github.com/krakenjs/zoid/compare/v10.5.1...v10.6.0-alpha.1) (2026-04-01)
-
-
-### Features
-
-* add bfcacheEnabled component option and gate parent guards in zoid ([846fcba](https://github.com/krakenjs/zoid/commit/846fcba81ce57aaf05c96a75753c194c12890344))
-* alpha version ([a79de90](https://github.com/krakenjs/zoid/commit/a79de90df4b4532cb12e161075570813cab190ec))
-* changes ([70a5c78](https://github.com/krakenjs/zoid/commit/70a5c7818e49dae80b031fcbc810f008307ca2d3))
-
-### [10.5.1](https://github.com/krakenjs/zoid/compare/v10.5.0...v10.5.1) (2026-03-23)
-
 ## [10.5.0](https://github.com/krakenjs/zoid/compare/v10.4.0...v10.5.0) (2026-01-07)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krakenjs/zoid",
-  "version": "10.5.1",
+  "version": "10.6.0-alpha.0",
   "description": "Cross domain components.",
   "main": "index.js",
   "scripts": {
@@ -113,7 +113,7 @@
     "standard-version": "^9.3.2"
   },
   "dependencies": {
-    "@krakenjs/belter": "^2.0.0",
+    "@krakenjs/belter": "2.10.0-alpha.4",
     "@krakenjs/cross-domain-utils": "^3.0.0",
     "@krakenjs/post-robot": "^11.0.0",
     "@krakenjs/zalgo-promise": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krakenjs/zoid",
-  "version": "10.6.0-alpha.0",
+  "version": "10.6.0-alpha.1",
   "description": "Cross domain components.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krakenjs/zoid",
-  "version": "10.6.0-alpha.1",
+  "version": "10.5.0",
   "description": "Cross domain components.",
   "main": "index.js",
   "scripts": {
@@ -113,7 +113,7 @@
     "standard-version": "^9.3.2"
   },
   "dependencies": {
-    "@krakenjs/belter": "2.10.0-alpha.4",
+    "@krakenjs/belter": "^2.10.1",
     "@krakenjs/cross-domain-utils": "^3.0.0",
     "@krakenjs/post-robot": "^11.0.0",
     "@krakenjs/zalgo-promise": "^2.0.0"

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -115,6 +115,7 @@ export function childComponent<P, X, C, ExtType>(
     exports: parentExports,
     context,
     props: initialProps,
+    enableBfcache,
   } = payload;
 
   if (!versionCompatabilityCheck(version, __ZOID__.__VERSION__)) {
@@ -228,7 +229,7 @@ export function childComponent<P, X, C, ExtType>(
 
     if ("onpagehide" in window) {
       window.addEventListener("pagehide", (event) => {
-        if (event.persisted) {
+        if (event.persisted && enableBfcache) {
           return;
         }
         checkClose.fireAndForget();

--- a/src/child/child.js
+++ b/src/child/child.js
@@ -227,7 +227,10 @@ export function childComponent<P, X, C, ExtType>(
     });
 
     if ("onpagehide" in window) {
-      window.addEventListener("pagehide", () => {
+      window.addEventListener("pagehide", (event) => {
+        if (event.persisted) {
+          return;
+        }
         checkClose.fireAndForget();
       });
     } else {

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -144,6 +144,8 @@ export type ComponentOptionsType<P, X, C, ExtType> = {|
   children?: () => C,
 
   exports?: ExportsDefinition<X>,
+
+  bfcacheEnabled?: boolean,
 |};
 
 export type AttributesType = {|
@@ -193,6 +195,8 @@ export type NormalizedComponentOptionsType<P, X, C, ExtType> = {|
   children: () => C,
 
   exports: ExportsMapperDefinition<X>,
+
+  bfcacheEnabled: boolean,
 |};
 
 export type ZoidComponentInstance<P, X = void, C = void, ExtType = void> = {|
@@ -280,6 +284,7 @@ function normalizeOptions<P, X, C, ExtType>(
     logger = { info: noop },
     exports: xportsDefinition = getDefaultExports(),
     method,
+    bfcacheEnabled = false,
     children = (): C => {
       // $FlowFixMe
       return {};
@@ -345,6 +350,7 @@ function normalizeOptions<P, X, C, ExtType>(
     children,
     exports: xports,
     getExtensions,
+    bfcacheEnabled,
   };
 }
 

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -145,7 +145,7 @@ export type ComponentOptionsType<P, X, C, ExtType> = {|
 
   exports?: ExportsDefinition<X>,
 
-  bfcacheEnabled?: boolean,
+  enableBfcache?: boolean,
 |};
 
 export type AttributesType = {|
@@ -196,7 +196,7 @@ export type NormalizedComponentOptionsType<P, X, C, ExtType> = {|
 
   exports: ExportsMapperDefinition<X>,
 
-  bfcacheEnabled: boolean,
+  enableBfcache: boolean,
 |};
 
 export type ZoidComponentInstance<P, X = void, C = void, ExtType = void> = {|
@@ -284,7 +284,7 @@ function normalizeOptions<P, X, C, ExtType>(
     logger = { info: noop },
     exports: xportsDefinition = getDefaultExports(),
     method,
-    bfcacheEnabled = false,
+    enableBfcache = false,
     children = (): C => {
       // $FlowFixMe
       return {};
@@ -350,7 +350,7 @@ function normalizeOptions<P, X, C, ExtType>(
     children,
     exports: xports,
     getExtensions,
-    bfcacheEnabled,
+    enableBfcache,
   };
 }
 

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -127,6 +127,7 @@ export type InitialChildPayload<P, X> = {|
   childDomainMatch: DomainMatcher,
   props: PropsType<P>,
   exports: ParentExportsType<P, X>,
+  enableBfcache: boolean,
 |};
 
 export type InitialChildPayloadMetadata = {|
@@ -296,7 +297,7 @@ export function parentComponent<P, X, C, ExtType>({
     domain: domainMatch,
     validate,
     exports: xports,
-    bfcacheEnabled,
+    enableBfcache,
   } = options;
 
   const initPromise = new ZalgoPromise();
@@ -859,7 +860,7 @@ export function parentComponent<P, X, C, ExtType>({
         eventname,
         (evt) => {
           const persisted = evt instanceof PageTransitionEvent && evt.persisted;
-          if (persisted && bfcacheEnabled) {
+          if (persisted && enableBfcache) {
             bfcacheEnterTime = Date.now();
             event.trigger(EVENT.BFCACHE_CACHE);
             return;
@@ -868,12 +869,16 @@ export function parentComponent<P, X, C, ExtType>({
         }
       );
 
-      if (bfcacheEnabled && "onpageshow" in window) {
+      if (enableBfcache && "onpageshow" in window) {
         const pageshowListener = addEventListener(window, "pageshow", (evt) => {
-          if (evt.persisted) {
-            const cachedDurationMs = bfcacheEnterTime
-              ? Date.now() - bfcacheEnterTime
-              : null;
+          const persisted =
+            typeof PageTransitionEvent !== "undefined" &&
+            evt instanceof PageTransitionEvent &&
+            evt.persisted;
+          if (persisted) {
+            const enterTime = bfcacheEnterTime;
+            const cachedDurationMs =
+              typeof enterTime === "number" ? Date.now() - enterTime : null;
             bfcacheEnterTime = null;
             event.trigger(EVENT.BFCACHE_RESTORE, { cachedDurationMs });
           }
@@ -1023,6 +1028,7 @@ export function parentComponent<P, X, C, ExtType>({
         version: __ZOID__.__VERSION__,
         props: childProps,
         exports: buildParentExports(proxyWin),
+        enableBfcache,
       };
     });
   };
@@ -1244,7 +1250,7 @@ export function parentComponent<P, X, C, ExtType>({
                 }
               });
             },
-            { bfcacheAware: bfcacheEnabled }
+            { isBfcacheEnabled: enableBfcache }
           );
 
           clean.register(() => containerWatcher.cancel());

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -296,6 +296,7 @@ export function parentComponent<P, X, C, ExtType>({
     domain: domainMatch,
     validate,
     exports: xports,
+    bfcacheEnabled,
   } = options;
 
   const initPromise = new ZalgoPromise();
@@ -851,31 +852,28 @@ export function parentComponent<P, X, C, ExtType>({
   const watchForUnload = () => {
     return ZalgoPromise.try(() => {
       const eventname = "onpagehide" in window ? "pagehide" : "unload";
-      let bfcacheEnterTime: ?number = null;
+      let bfcacheEnterTime = null;
 
       const unloadWindowListener = addEventListener(
         window,
         eventname,
         (evt) => {
           const persisted = evt instanceof PageTransitionEvent && evt.persisted;
-          if (persisted) {
+          if (persisted && bfcacheEnabled) {
             bfcacheEnterTime = Date.now();
             event.trigger(EVENT.BFCACHE_CACHE);
+            return;
           }
           destroy(new Error(COMPONENT_ERROR.NAVIGATED_AWAY));
         }
       );
 
-      if ("onpageshow" in window) {
+      if (bfcacheEnabled && "onpageshow" in window) {
         const pageshowListener = addEventListener(window, "pageshow", (evt) => {
-          const persisted = evt instanceof PageTransitionEvent && evt.persisted;
-          if (persisted) {
-            // Flow can't narrow ?number through closures in ternaries, so capture locally first
-            const enterTime = bfcacheEnterTime;
-            const cachedDurationMs =
-              enterTime !== null && enterTime !== undefined
-                ? Date.now() - enterTime
-                : null;
+          if (evt.persisted) {
+            const cachedDurationMs = bfcacheEnterTime
+              ? Date.now() - bfcacheEnterTime
+              : null;
             bfcacheEnterTime = null;
             event.trigger(EVENT.BFCACHE_RESTORE, { cachedDurationMs });
           }
@@ -1231,19 +1229,23 @@ export function parentComponent<P, X, C, ExtType>({
             hideElement(innerContainer);
           }
           appendChild(container, innerContainer);
-          const containerWatcher = watchElementForClose(innerContainer, () => {
-            const removeError = new Error(
-              `Detected container element removed from DOM`
-            );
-            return ZalgoPromise.delay(1).then(() => {
-              if (isElementClosed(innerContainer)) {
-                close(removeError);
-              } else {
-                clean.all(removeError);
-                return rerender().then(resolveInitPromise, rejectInitPromise);
-              }
-            });
-          });
+          const containerWatcher = watchElementForClose(
+            innerContainer,
+            () => {
+              const removeError = new Error(
+                `Detected container element removed from DOM`
+              );
+              return ZalgoPromise.delay(1).then(() => {
+                if (isElementClosed(innerContainer)) {
+                  close(removeError);
+                } else {
+                  clean.all(removeError);
+                  return rerender().then(resolveInitPromise, rejectInitPromise);
+                }
+              });
+            },
+            { bfcacheAware: bfcacheEnabled }
+          );
 
           clean.register(() => containerWatcher.cancel());
           clean.register(() => destroyElement(innerContainer));

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -859,7 +859,8 @@ export function parentComponent<P, X, C, ExtType>({
         window,
         eventname,
         (evt) => {
-          const persisted = evt instanceof PageTransitionEvent && evt.persisted;
+          // $FlowFixMe
+          const persisted = Boolean(evt.persisted);
           if (persisted && enableBfcache) {
             bfcacheEnterTime = Date.now();
             event.trigger(EVENT.BFCACHE_CACHE);
@@ -871,10 +872,8 @@ export function parentComponent<P, X, C, ExtType>({
 
       if (enableBfcache && "onpageshow" in window) {
         const pageshowListener = addEventListener(window, "pageshow", (evt) => {
-          const persisted =
-            typeof PageTransitionEvent !== "undefined" &&
-            evt instanceof PageTransitionEvent &&
-            evt.persisted;
+          // $FlowFixMe
+          const persisted = Boolean(evt.persisted);
           if (persisted) {
             const enterTime = bfcacheEnterTime;
             const cachedDurationMs =

--- a/test/tests/error.js
+++ b/test/tests/error.js
@@ -802,6 +802,85 @@ describe("zoid error cases", () => {
     });
   });
 
+  it("should not call onDestroy when the page enters bfcache and enableBfcache is true", () => {
+    return wrapPromise(({ expect, avoid }) => {
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-bfcache-enter-enabled",
+          url: "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+          enableBfcache: true,
+        });
+      };
+
+      const testComplete = expect("testComplete");
+      const component = window.__component__();
+      return component({
+        onError: avoid("onError"),
+        onDestroy: avoid("onDestroy"),
+      })
+        .render(getBody(), zoid.CONTEXT.IFRAME)
+        .then(() => {
+          window.dispatchEvent(
+            new PageTransitionEvent("pagehide", { persisted: true })
+          );
+          return ZalgoPromise.delay(50);
+        })
+        .then(() => {
+          testComplete();
+        });
+    });
+  });
+
+  it("should call onDestroy when the page enters bfcache but enableBfcache is false (default)", () => {
+    return wrapPromise(({ expect, avoid }) => {
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-bfcache-enter-disabled",
+          url: "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+        });
+      };
+
+      const component = window.__component__();
+      return component({
+        onError: avoid("onError"),
+        onDestroy: expect("onDestroy"),
+      })
+        .render(getBody(), zoid.CONTEXT.IFRAME)
+        .then(() => {
+          window.dispatchEvent(
+            new PageTransitionEvent("pagehide", { persisted: true })
+          );
+        });
+    });
+  });
+
+  it("should call onDestroy on a real unload even when enableBfcache is true", () => {
+    return wrapPromise(({ expect, avoid }) => {
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-bfcache-real-unload",
+          url: "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+          enableBfcache: true,
+        });
+      };
+
+      const component = window.__component__();
+      return component({
+        onError: avoid("onError"),
+        onDestroy: expect("onDestroy"),
+      })
+        .render(getBody(), zoid.CONTEXT.IFRAME)
+        .then(() => {
+          window.dispatchEvent(
+            new PageTransitionEvent("pagehide", { persisted: false })
+          );
+        });
+    });
+  });
+
   it("should call onDestroy even if component is not eligible", () => {
     return wrapPromise(({ expect, avoid }) => {
       window.__component__ = () => {


### PR DESCRIPTION
Add bfcacheEnabled as a first-class zoid component option so checkout-components can pass it through from the ELMO experiment. When enabled, parent-side watchForUnload skips destroy on bfcache entry, adds a pageshow listener for restore detection, and passes bfcacheAware to belter's watchElementForClose. When disabled (default), behavior is identical to current production.

[https://paypal.atlassian.net/browse/DTPPCPSDK-5699](url)

<img width="914" height="654" alt="Screenshot 2026-03-25 at 9 38 50 AM" src="https://github.com/user-attachments/assets/5d8e0971-8dcc-4e1d-a072-0d6cbd6effe0" />
