### PR TITLE
[Feature] Re-render PayPal Button on `onCancel` and `onError`

### DIFF
--- a/src/component/component.js
+++ b/src/component/component.js
@@ -32,6 +32,7 @@ import {
   type ParentComponent,
   type RenderOptionsType,
   type ParentHelpers,
+  type RerenderOptions,
   parentComponent,
 } from "../parent/parent";
 import {
@@ -201,7 +202,9 @@ export type ZoidComponentInstance<P, X = void, C = void, ExtType = void> = {|
   ...X,
   ...C,
   isEligible: () => boolean,
-  clone: () => ZoidComponentInstance<P, X, C, ExtType>,
+  clone: (
+    options?: RerenderOptions<P>
+  ) => ZoidComponentInstance<P, X, C, ExtType>,
   render: (
     container?: ContainerReferenceType,
     context?: $Values<typeof CONTEXT>
@@ -384,6 +387,175 @@ export function component<P, X, C, ExtType>(
   const global = getGlobal(window);
   const driverCache = {};
   const instances = [];
+  let latestRenderedRerender: ?(
+    options?: RerenderOptions<P>
+  ) => ZalgoPromise<void>;
+  const latestRenderStorageKey = `__zoid_latest_render__${tag}`;
+  const latestRenderContainerAttr = `data-zoid-latest-container-${tag}`;
+  const escapeAttr = (value: string): string => {
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  };
+  const waitForSelector = (
+    selector: string,
+    timeout: number = 3000,
+    interval: number = 100
+  ): ZalgoPromise<string> => {
+    return new ZalgoPromise((resolve, reject) => {
+      const start = Date.now();
+
+      const check = () => {
+        try {
+          if (document.querySelector(selector)) {
+            resolve(selector);
+            return;
+          }
+        } catch (err) {
+          reject(err);
+          return;
+        }
+
+        if (Date.now() - start >= timeout) {
+          reject(
+            new Error(
+              `Timed out waiting for container selector to appear: ${selector}`
+            )
+          );
+          return;
+        }
+
+        setTimeout(check, interval);
+      };
+
+      check();
+    });
+  };
+
+  const readLatestRender = (): ?{|
+    container: string,
+    context: $Values<typeof CONTEXT>,
+  |} => {
+    try {
+      if (!window.sessionStorage) {
+        return;
+      }
+
+      const latestRender = window.sessionStorage.getItem(
+        latestRenderStorageKey
+      );
+      if (!latestRender) {
+        return;
+      }
+
+      const parsed = JSON.parse(latestRender);
+      const persistedContainers =
+        parsed && Array.isArray(parsed.containers)
+          ? parsed.containers.filter(
+              (candidate) => typeof candidate === "string"
+            )
+          : [];
+
+      let candidates = persistedContainers;
+
+      if (candidates.length === 0) {
+        if (parsed && typeof parsed.container === "string") {
+          candidates = [parsed.container];
+        } else {
+          candidates = [];
+        }
+      }
+
+      if (!parsed || candidates.length === 0) {
+        return;
+      }
+
+      if (
+        parsed.context !== CONTEXT.IFRAME &&
+        parsed.context !== CONTEXT.POPUP
+      ) {
+        return;
+      }
+
+      const container =
+        candidates.find((candidate) => {
+          try {
+            return Boolean(document.querySelector(candidate));
+          } catch (err) {
+            return false;
+          }
+        }) || candidates[0];
+
+      return {
+        container,
+        context: parsed.context,
+      };
+    } catch (err) {
+      // ignored
+    }
+  };
+
+  const writeLatestRender = (
+    container: ContainerReferenceType,
+    context: $Values<typeof CONTEXT>
+  ) => {
+    let persistedContainer: ?string;
+    const persistedContainers = [];
+
+    if (typeof container === "string") {
+      persistedContainer = container;
+      persistedContainers.push(container);
+    } else if (isElement(container)) {
+      const elementID = container.getAttribute("id");
+      if (elementID) {
+        persistedContainers.push(`[id="${escapeAttr(elementID)}"]`);
+      }
+
+      const elementName = container.getAttribute("name");
+      if (elementName) {
+        persistedContainers.push(`[name="${escapeAttr(elementName)}"]`);
+      }
+
+      const className = container.className;
+      if (typeof className === "string" && className.trim()) {
+        const firstClass = className.trim().split(/\s+/)[0];
+        if (firstClass) {
+          persistedContainers.push(`.${firstClass}`);
+        }
+      }
+
+      let marker = container.getAttribute(latestRenderContainerAttr);
+
+      if (!marker) {
+        marker = uniqueID();
+        container.setAttribute(latestRenderContainerAttr, marker);
+      }
+
+      persistedContainers.push(
+        `[${latestRenderContainerAttr}="${escapeAttr(marker)}"]`
+      );
+      persistedContainer = persistedContainers[0];
+    }
+
+    if (!persistedContainer) {
+      return;
+    }
+
+    try {
+      if (!window.sessionStorage) {
+        return;
+      }
+
+      window.sessionStorage.setItem(
+        latestRenderStorageKey,
+        JSON.stringify({
+          container: persistedContainer,
+          containers: persistedContainers,
+          context,
+        })
+      );
+    } catch (err) {
+      // ignored
+    }
+  };
 
   const isChild = (): boolean => {
     if (isChildComponentWindow(name)) {
@@ -518,9 +690,31 @@ export function component<P, X, C, ExtType>(
       }
     };
 
+    const clone = ({ decorate = identity }: RerenderOptions<P> = {}) => {
+      return init(decorate(props));
+    };
+
     const parent = parentComponent({
       uid,
       options,
+      getFallbackRerender: () => {
+        if (latestRenderedRerender) {
+          return latestRenderedRerender;
+        }
+
+        const latestRender = readLatestRender();
+        if (!latestRender) {
+          return;
+        }
+
+        return (rerenderOptions) => {
+          return waitForSelector(latestRender.container).then((selector) => {
+            const newInstance = clone(rerenderOptions);
+            extend(instance, newInstance);
+            return newInstance.render(selector, latestRender.context);
+          });
+        };
+      },
     });
 
     parent.init();
@@ -536,10 +730,6 @@ export function component<P, X, C, ExtType>(
     cleanInstances.register((err) => {
       return parent.destroy(err || new Error(`zoid destroyed all components`));
     });
-
-    const clone = ({ decorate = identity } = {}) => {
-      return init(decorate(props));
-    };
 
     const getChildren = (): C => {
       // $FlowFixMe
@@ -597,15 +787,20 @@ export function component<P, X, C, ExtType>(
             );
           }
 
+          const rerender = (rerenderOptions) => {
+            const newInstance = clone(rerenderOptions);
+            extend(instance, newInstance);
+            return newInstance.renderTo(target, container, context);
+          };
+
+          latestRenderedRerender = rerender;
+          writeLatestRender(container, finalContext);
+
           return parent.render({
             target,
             container,
             context: finalContext,
-            rerender: () => {
-              const newInstance = clone();
-              extend(instance, newInstance);
-              return newInstance.renderTo(target, container, context);
-            },
+            rerender,
           });
         })
         .catch((err) => {

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -136,6 +136,10 @@ export type InitialChildPayloadMetadata = {|
 
 export type StateType = Object;
 
+export type RerenderOptions<P> = {|
+  decorate?: (PropsInputType<P>) => PropsInputType<P>,
+|};
+
 export type ParentHelpers<P> = {|
   state: StateType,
   close: () => ZalgoPromise<void>,
@@ -146,6 +150,7 @@ export type ParentHelpers<P> = {|
   event: EventEmitterType,
   show: () => ZalgoPromise<void>,
   hide: () => ZalgoPromise<void>,
+  rerender: (options?: RerenderOptions<P>) => ZalgoPromise<void>,
 |};
 
 function getDefaultProps<P>(): PropsType<P> {
@@ -157,13 +162,13 @@ type InternalState = {|
   visible: boolean,
 |};
 
-type Rerender = () => ZalgoPromise<void>;
+type Rerender<P> = (options?: RerenderOptions<P>) => ZalgoPromise<void>;
 
-type RenderContainerOptions = {|
+type RenderContainerOptions<P> = {|
   context: $Values<typeof CONTEXT>,
   proxyFrame: ?ProxyObject<HTMLIFrameElement>,
   proxyPrerenderFrame: ?ProxyObject<HTMLIFrameElement>,
-  rerender: Rerender,
+  rerender: Rerender<P>,
 |};
 
 type ResolveInitPromise = () => ZalgoPromise<void>;
@@ -175,9 +180,9 @@ type Show = () => ZalgoPromise<void>;
 type Hide = () => ZalgoPromise<void>;
 type Close = () => ZalgoPromise<void>;
 type OnError = (mixed) => ZalgoPromise<void>;
-type RenderContainer = (
+type RenderContainer<P> = (
   proxyContainer: ProxyObject<HTMLElement>,
-  RenderContainerOptions
+  RenderContainerOptions<P>
 ) => ZalgoPromise<?ProxyObject<HTMLElement>>;
 type SetProxyWin = (ProxyWindow) => ZalgoPromise<void>;
 type GetProxyWindow = () => ZalgoPromise<ProxyWindow>;
@@ -208,6 +213,7 @@ type OpenPrerender = (
 type WatchForUnload = () => ZalgoPromise<void>;
 type GetInternalState = () => ZalgoPromise<InternalState>;
 type SetInternalState = (InternalState) => ZalgoPromise<InternalState>;
+type GetFallbackRerender<P> = () => ?Rerender<P>;
 
 type ParentDelegateOverrides<P> = {|
   props: PropsType<P>,
@@ -217,7 +223,7 @@ type ParentDelegateOverrides<P> = {|
   getProxyContainer: GetProxyContainer,
   show: Show,
   hide: Hide,
-  renderContainer: RenderContainer,
+  renderContainer: RenderContainer<P>,
   getProxyWindow: GetProxyWindow,
   setProxyWin: SetProxyWin,
   openFrame: OpenFrame,
@@ -232,11 +238,11 @@ type ParentDelegateOverrides<P> = {|
   rejectInitPromise: RejectInitPromise,
 |};
 
-type DelegateOverrides = {|
+type DelegateOverrides<P> = {|
   getProxyContainer: GetProxyContainer,
   show: Show,
   hide: Hide,
-  renderContainer: RenderContainer,
+  renderContainer: RenderContainer<P>,
   getProxyWindow: GetProxyWindow,
   setProxyWin: SetProxyWin,
   openFrame: OpenFrame,
@@ -247,22 +253,22 @@ type DelegateOverrides = {|
   watchForUnload: WatchForUnload,
 |};
 
-type RenderOptions = {|
+type RenderOptions<P> = {|
   target: CrossDomainWindowType,
   container: ContainerReferenceType,
   context: $Values<typeof CONTEXT>,
-  rerender: Rerender,
+  rerender: Rerender<P>,
 |};
 
 export type ParentComponent<P, X> = {|
   init: () => void,
-  render: (RenderOptions) => ZalgoPromise<void>,
+  render: (RenderOptions<P>) => ZalgoPromise<void>,
   getProps: () => PropsType<P>,
   setProps: (newProps: PropsInputType<P>, isUpdate?: boolean) => void,
   export: (X) => ZalgoPromise<void>,
   destroy: (err?: mixed) => ZalgoPromise<void>,
   getHelpers: () => ParentHelpers<P>,
-  getDelegateOverrides: () => ZalgoPromise<DelegateOverrides>,
+  getDelegateOverrides: () => ZalgoPromise<DelegateOverrides<P>>,
   getExports: () => X,
 |};
 
@@ -276,6 +282,7 @@ type ParentOptions<P, X, C, ExtType> = {|
   options: NormalizedComponentOptionsType<P, X, C, ExtType>,
   overrides?: ParentDelegateOverrides<P>,
   parentWin?: CrossDomainWindowType,
+  getFallbackRerender?: GetFallbackRerender<P>,
 |};
 
 export function parentComponent<P, X, C, ExtType>({
@@ -283,6 +290,7 @@ export function parentComponent<P, X, C, ExtType>({
   options,
   overrides = getDefaultOverrides(),
   parentWin = window,
+  getFallbackRerender = () => null,
 }: ParentOptions<P, X, C, ExtType>): ParentComponent<P, X> {
   const {
     propsDef,
@@ -317,6 +325,9 @@ export function parentComponent<P, X, C, ExtType>({
   let childComponent: ?ChildExportsType<P>;
   let currentChildDomain: ?string;
   let currentContainer: HTMLElement | void;
+  let currentRerender: ?Rerender<P> = null;
+  let lastRerender: ?Rerender<P> = null;
+  let hasBeenRendered: boolean = false;
   let isRenderFinished: boolean = false;
 
   const onErrorOverride: ?OnError = overrides.onError;
@@ -325,7 +336,7 @@ export function parentComponent<P, X, C, ExtType>({
   let showOverride: ?Show = overrides.show;
   let hideOverride: ?Hide = overrides.hide;
   const closeOverride: ?Close = overrides.close;
-  let renderContainerOverride: ?RenderContainer = overrides.renderContainer;
+  let renderContainerOverride: ?RenderContainer<P> = overrides.renderContainer;
   let getProxyWindowOverride: ?GetProxyWindow = overrides.getProxyWindow;
   let setProxyWinOverride: ?SetProxyWin = overrides.setProxyWin;
   let openFrameOverride: ?OpenFrame = overrides.openFrame;
@@ -1168,14 +1179,14 @@ export function parentComponent<P, X, C, ExtType>({
       event.trigger(EVENT.PRERENDERED);
     });
   };
-  const renderContainer: RenderContainer = (
+  const renderContainer: RenderContainer<P> = (
     proxyContainer: ProxyObject<HTMLElement>,
     {
       proxyFrame,
       proxyPrerenderFrame,
       context,
       rerender,
-    }: RenderContainerOptions
+    }: RenderContainerOptions<P>
   ): ZalgoPromise<?ProxyObject<HTMLElement>> => {
     if (renderContainerOverride) {
       return renderContainerOverride(proxyContainer, {
@@ -1280,6 +1291,22 @@ export function parentComponent<P, X, C, ExtType>({
       updateProps,
       show,
       hide,
+      rerender: (rerenderOptions) => {
+        const fallbackRerender = getFallbackRerender();
+        const rerenderFn = currentRerender || lastRerender || fallbackRerender;
+
+        if (!rerenderFn) {
+          if (!hasBeenRendered) {
+            throw new Error(
+              "Rerender not available - component must be rendered first."
+            );
+          }
+          throw new Error(
+            "Rerender callback lost after render - component may be destroyed or re-initialized."
+          );
+        }
+        return rerenderFn(rerenderOptions);
+      },
     };
   };
 
@@ -1351,7 +1378,7 @@ export function parentComponent<P, X, C, ExtType>({
   const delegate = (
     context: $Values<typeof CONTEXT>,
     target: CrossDomainWindowType
-  ): ZalgoPromise<DelegateOverrides> => {
+  ): ZalgoPromise<DelegateOverrides<P>> => {
     const delegateProps = {};
     for (const propName of Object.keys(props)) {
       const propDef = propsDef[propName];
@@ -1451,7 +1478,7 @@ export function parentComponent<P, X, C, ExtType>({
     return childOverridesPromise;
   };
 
-  const getDelegateOverrides = (): ZalgoPromise<DelegateOverrides> => {
+  const getDelegateOverrides = (): ZalgoPromise<DelegateOverrides<P>> => {
     return ZalgoPromise.try(() => {
       return {
         getProxyContainer,
@@ -1507,8 +1534,11 @@ export function parentComponent<P, X, C, ExtType>({
     container,
     context,
     rerender,
-  }: RenderOptions): ZalgoPromise<void> => {
+  }: RenderOptions<P>): ZalgoPromise<void> => {
     return ZalgoPromise.try(() => {
+      currentRerender = rerender;
+      lastRerender = rerender;
+      hasBeenRendered = true;
       const initialChildDomain = getInitialChildDomain();
       const childDomainMatch = getDomainMatcher();
 

--- a/test/tests/rerender.js
+++ b/test/tests/rerender.js
@@ -116,6 +116,64 @@ describe("zoid rerender cases", () => {
     });
   });
 
+  it("should re-render a component with decorated props", () => {
+    return wrapPromise(({ expect, avoid }) => {
+      window.__component__ = () => {
+        return zoid.create({
+          tag: "test-rerender-decorated-props",
+          url: "mock://www.child.com/base/test/windows/child/index.htm",
+          domain: "mock://www.child.com",
+          exports: ({ getExports }) => {
+            return {
+              exec: (...args) => {
+                return getExports().then((exports) => {
+                  return exports.exec(...args);
+                });
+              },
+            };
+          },
+        });
+      };
+
+      const container = document.createElement("div");
+      getBody().appendChild(container);
+
+      const component = window.__component__();
+      const instance = component({
+        onRendered: expect("onRendered"),
+        onClose: avoid("onClose"),
+        onDestroy: avoid("onDestroy"),
+        onError: avoid("onError"),
+        getValue: avoid("getValue"),
+        run: () => `
+                    window.xprops.export({
+                        exec: (code) => eval(code)
+                    });
+                `,
+      });
+
+      return instance
+        .render(container)
+        .then(() => {
+          return instance.rerender({
+            decorate: (props) => ({
+              ...props,
+              getValue: expect("getValue", () => "decorated-value"),
+            }),
+          });
+        })
+        .then(() => {
+          return instance.exec(`
+                    window.xprops.getValue().then((value) => {
+                        if (value !== "decorated-value") {
+                            throw new Error("Expected decorated prop value");
+                        }
+                    });
+                `);
+        });
+    });
+  });
+
   it("should render a component to the parent as an iframe and re-render when the container is removed and immediately re-added to the dom", () => {
     return wrapPromise(({ expect, avoid }) => {
       window.__component__ = () => {


### PR DESCRIPTION
 ### Description

Updates Zoid rerender behavior so a component can be re-rendered into its original container with decorated props.

**Problem:** In app switch resume cancel flows, PayPal Checkout needs to render a fresh button after the merchant `onCancel` callback while preserving resume-specific props, such as reusing the returned `orderID` for retry. Zoid owned the original render target, but `rerender()` could only clone with the original props.

**Solution:** Extend Zoid `rerender()` to accept an optional prop decorator. The rerender path still uses Zoid’s existing target/container/context handling, while callers can override selected props for the new instance.

**Impact:** PayPal Checkout can restore the button after app switch cancel flows without hardcoding merchant container selectors or moving render-target logic into PPC.

### Why are we making these changes?

  1. DTRIMAC-2082
  2. DTPPCPSDK-4375

### Reproduction Steps

Same reproduction flow as the paired paypal-checkout-components PR: https://github.com/paypal/paypal-checkout-components/pull/2592.

### Dependent Changes

To be tested with the paired paypal-checkout-components PR: https://github.com/paypal/paypal-checkout-components/pull/2592 and SCNW PR: #1183.