### PR TITLE
Add EVENT.BFCACHE zoid events (re-apply #478)

### DIFF
--- a/src/component/props.js
+++ b/src/component/props.js
@@ -50,6 +50,10 @@ export type onClosePropType = EventHandlerType<void>;
 export type onDestroyPropType = EventHandlerType<void>;
 export type onResizePropType = EventHandlerType<void>;
 export type onFocusPropType = EventHandlerType<void>;
+export type onBfcacheCachePropType = EventHandlerType<void>;
+export type onBfcacheRestorePropType = EventHandlerType<{|
+  cachedDurationMs: ?number,
+|}>;
 export type onErrorPropType = EventHandlerType<mixed>;
 // eslint-disable-next-line no-use-before-define
 export type onPropsPropType<P> = ((PropsType<P>) => void) => {|
@@ -79,6 +83,8 @@ export type PropsInputType<P> = {|
   onDestroy?: onDestroyPropType,
   onResize?: onResizePropType,
   onFocus?: onFocusPropType,
+  onBfcacheCache?: onBfcacheCachePropType,
+  onBfcacheRestore?: onBfcacheRestorePropType,
   onError?: onErrorPropType,
   onProps?: onPropsPropType<P>,
 
@@ -101,6 +107,8 @@ export type PropsType<P> = {|
   onResize: onResizePropType,
   onFocus: onFocusPropType,
   onError: onErrorPropType,
+  onBfcacheCache: EventHandlerType<void>,
+  onBfcacheRestore: EventHandlerType<{| cachedDurationMs: ?number |}>,
   onProps: onPropsPropType<P>,
 
   ...P,
@@ -284,6 +292,8 @@ export type BuiltInPropsDefinitionType<P, X> = {|
   onDestroy: FunctionPropDefinitionType<onDestroyPropType, P, X>,
   onResize: FunctionPropDefinitionType<onClosePropType, P, X>,
   onFocus: FunctionPropDefinitionType<onFocusPropType, P, X>,
+  onBfcacheCache: FunctionPropDefinitionType<onBfcacheCachePropType, P, X>,
+  onBfcacheRestore: FunctionPropDefinitionType<onBfcacheRestorePropType, P, X>,
   onError: FunctionPropDefinitionType<onErrorPropType, P, X>,
   onProps: FunctionPropDefinitionType<onPropsPropType<P>, P, X>,
 |};
@@ -405,6 +415,25 @@ export function getBuiltInProps<P, X>(): BuiltInPropsDefinitionType<P, X> {
     },
 
     onFocus: {
+      type: PROP_TYPE.FUNCTION,
+      required: false,
+      sendToChild: false,
+      allowDelegate: true,
+      default: defaultNoop,
+    },
+
+    // Note: decorateOnce is intentionally omitted for bfcache events.
+    // Unlike other lifecycle props, these can fire multiple times as the page
+    // transitions in and out of bfcache (cache -> restore -> cache -> restore).
+    onBfcacheCache: {
+      type: PROP_TYPE.FUNCTION,
+      required: false,
+      sendToChild: false,
+      allowDelegate: true,
+      default: defaultNoop,
+    },
+
+    onBfcacheRestore: {
       type: PROP_TYPE.FUNCTION,
       required: false,
       sendToChild: false,

--- a/src/constants.js
+++ b/src/constants.js
@@ -60,6 +60,8 @@ export const EVENT = {
   PROPS: "zoid-props",
   RESIZE: "zoid-resize",
   FOCUS: "zoid-focus",
+  BFCACHE_CACHE: "zoid-bfcache-cache",
+  BFCACHE_RESTORE: "zoid-bfcache-restore",
 };
 
 export const METHOD = {

--- a/src/parent/parent.js
+++ b/src/parent/parent.js
@@ -39,7 +39,6 @@ import {
   extendUrl,
   appendChild,
   cleanup,
-  once,
   stringifyError,
   destroyElement,
   getElementSafe,
@@ -413,6 +412,8 @@ export function parentComponent<P, X, C, ExtType>({
     event.on(EVENT.DESTROY, () => props.onDestroy());
     event.on(EVENT.RESIZE, () => props.onResize());
     event.on(EVENT.FOCUS, () => props.onFocus());
+    event.on(EVENT.BFCACHE_CACHE, () => props.onBfcacheCache());
+    event.on(EVENT.BFCACHE_RESTORE, (data) => props.onBfcacheRestore(data));
     event.on(EVENT.PROPS, (newProps) => props.onProps(newProps));
     event.on(EVENT.ERROR, (err) => {
       if (props && props.onError) {
@@ -850,14 +851,37 @@ export function parentComponent<P, X, C, ExtType>({
   const watchForUnload = () => {
     return ZalgoPromise.try(() => {
       const eventname = "onpagehide" in window ? "pagehide" : "unload";
+      let bfcacheEnterTime: ?number = null;
 
       const unloadWindowListener = addEventListener(
         window,
         eventname,
-        once(() => {
+        (evt) => {
+          const persisted = evt instanceof PageTransitionEvent && evt.persisted;
+          if (persisted) {
+            bfcacheEnterTime = Date.now();
+            event.trigger(EVENT.BFCACHE_CACHE);
+          }
           destroy(new Error(COMPONENT_ERROR.NAVIGATED_AWAY));
-        })
+        }
       );
+
+      if ("onpageshow" in window) {
+        const pageshowListener = addEventListener(window, "pageshow", (evt) => {
+          const persisted = evt instanceof PageTransitionEvent && evt.persisted;
+          if (persisted) {
+            // Flow can't narrow ?number through closures in ternaries, so capture locally first
+            const enterTime = bfcacheEnterTime;
+            const cachedDurationMs =
+              enterTime !== null && enterTime !== undefined
+                ? Date.now() - enterTime
+                : null;
+            bfcacheEnterTime = null;
+            event.trigger(EVENT.BFCACHE_RESTORE, { cachedDurationMs });
+          }
+        });
+        clean.register(pageshowListener.cancel);
+      }
 
       const closeParentWindowListener = onCloseWindow(parentWin, destroy, 3000);
       clean.register(closeParentWindowListener.cancel);


### PR DESCRIPTION
## Summary

Re-applies #478 (`EVENT.BFCACHE_CACHE`/`EVENT.BFCACHE_RESTORE` lifecycle events), which was reverted by #480 on 2026-04-03.

This is a straight `git revert` of the revert commit (`49047ed`) — verified line-for-line identical to the original #478 diff, no code changes. #478 and #480 don't touch any files modified by #484 (global key strategy fix), so there's no merge conflict or interaction between them.

## Why the original revert happened

The 2026-04-03 revert was not a defect in this diff itself. It was caused by zoid's version-baked `__GLOBAL_KEY__` breaking `passByReference` serialization whenever parent and child windows loaded different zoid versions on the same domain during rollout (~16,000 excess `SDK_INTEGRATION_LOADING_ERROR`s). That root cause has since been fixed in #484 (`fix: change global key strategy`, merged and published as part of `10.5.3`), which shares a major-version-keyed global across all `10.x` releases instead of keying on the full version string. Phase 2 of that fix will follow once the bfcache work (this PR, #479, and downstream PCC/SCNW work) is complete.

## Test plan

Used Custom BFcache test harness 

<img width="561" height="811" alt="Screenshot 2026-07-07 at 1 17 20 PM" src="https://github.com/user-attachments/assets/7f1d0df8-d326-4eea-b885-e73849309084" />


DTPPCPSDK-5691